### PR TITLE
Improve header properties responsiveness

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // ===================================
     // === LÓGICA DEL MENÚ HAMBURGUESA ===
     // ===================================
-    const menuToggle = document.querySelector('.header__toggle');
+    const menuToggles = document.querySelectorAll('.header__toggle, .header-props__toggle');
     const navMenu = document.querySelector('.mobile-nav__list');
     const closeMenu = document.querySelector('.mobile-nav__close-button');
     const pageOverlay = document.querySelector('.mobile-nav__overlay');
@@ -20,8 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (pageOverlay) pageOverlay.classList.remove('active');
     };
 
-    if (menuToggle) {
-        menuToggle.addEventListener('click', openNav);
+    if (menuToggles.length) {
+        menuToggles.forEach(btn => btn.addEventListener('click', openNav));
     }
     if (closeMenu) {
         closeMenu.addEventListener('click', closeNav);

--- a/includes/header_properties.php
+++ b/includes/header_properties.php
@@ -14,12 +14,24 @@
                 </div>
             </div>
             <div class="header-props__center">
-            <div class="header-props__search-bar">
-                <input type="text" placeholder="Buscar..." class="header-props__search-input">
-                <button class="header-props__search-button">
-                <img src="assets/images/iconcaracteristic/search-icon.png" alt="Buscar">
-                </button>
-            </div>
+                <form class="header-props__search-bar" action="properties.php" method="get">
+                    <input
+                        type="text"
+                        name="search"
+                        placeholder="Buscar..."
+                        value="<?php echo isset($search) ? htmlspecialchars($search) : ''; ?>"
+                        class="header-props__search-input">
+                    <input type="hidden" name="listing_type" value="<?php echo htmlspecialchars($listing_type ?? 'venta'); ?>">
+                    <?php if (!empty($category)): ?>
+                        <input type="hidden" name="category" value="<?php echo htmlspecialchars($category); ?>">
+                    <?php endif; ?>
+                    <?php if (!empty($location)): ?>
+                        <input type="hidden" name="location" value="<?php echo htmlspecialchars($location); ?>">
+                    <?php endif; ?>
+                    <button class="header-props__search-button" type="submit">
+                        <img src="assets/images/iconcaracteristic/search-icon.png" alt="Buscar">
+                    </button>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- make the search bar a form so filters persist
- support `.header-props__toggle` in JS mobile menu logic
- ensure final newline at end of files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ac019cdfc83208912d5a72495f3a6