### PR TITLE
Improve header properties responsiveness

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3406,11 +3406,14 @@ body:not(.home) header .header__toggle-line {
 .header-props__search-bar {
     width: 100%;
     max-width: 800px;     /* aumenta el largo máximo */
-    
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+
     /* padding vertical reducido para que sea más delgada */
-    padding: 6px 20px;    
+    padding: 6px 20px;
     height: 36px;         /* altura fija y fina */
-    
+
     border: 1px solid #e0e0e0;
     border-radius: 25px;  /* mantiene la forma ovalada */
     background-color: #f9f9f9;
@@ -3454,9 +3457,13 @@ body:not(.home) header .header__toggle-line {
 }
 
 .header-props__search-input {
+    flex: 1;
     padding: 0 12px;      /* sin padding vertical */
     line-height: 36px;    /* centra el texto verticalmente */
     font-size: 15px;
+    border: none;
+    background: transparent;
+    outline: none;
 }
 
 .header-props__search-button {
@@ -3467,7 +3474,7 @@ body:not(.home) header .header__toggle-line {
 }
 
 .header-props__search-button img {
-    height: 20px;
+    height: 22px;
     opacity: 0.5;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // ===================================
     // === LÓGICA DEL MENÚ HAMBURGUESA ===
     // ===================================
-    const menuToggle = document.querySelector('.header__toggle');
+    const menuToggles = document.querySelectorAll('.header__toggle, .header-props__toggle');
     const navMenu = document.querySelector('.mobile-nav__list');
     const closeMenu = document.querySelector('.mobile-nav__close-button');
     const pageOverlay = document.querySelector('.mobile-nav__overlay');
@@ -20,8 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (pageOverlay) pageOverlay.classList.remove('active');
     };
 
-    if (menuToggle) {
-        menuToggle.addEventListener('click', openNav);
+    if (menuToggles.length) {
+        menuToggles.forEach(btn => btn.addEventListener('click', openNav));
     }
     if (closeMenu) {
         closeMenu.addEventListener('click', closeNav);
@@ -199,6 +199,35 @@ if (initialTab) {
             link.classList.add('active');
         }
     });
+
+    const searchForm = document.getElementById('props-search-form');
+    const categorySelect = document.getElementById('category-select');
+    const locationSelect = document.getElementById('location-select');
+
+    function updateHiddenAndSubmit(name, value) {
+        if (!searchForm) return;
+        let input = searchForm.querySelector(`input[name="${name}"]`);
+        if (!input) {
+            input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = name;
+            searchForm.appendChild(input);
+        }
+        input.value = value;
+        searchForm.submit();
+    }
+
+    if (categorySelect) {
+        categorySelect.addEventListener('change', () => {
+            updateHiddenAndSubmit('category', categorySelect.value);
+        });
+    }
+
+    if (locationSelect) {
+        locationSelect.addEventListener('change', () => {
+            updateHiddenAndSubmit('location', locationSelect.value);
+        });
+    }
 
     // ============================================
     // === LÓGICA PARA CARRUSELES DE PROPIEDADES ===

--- a/includes/header_properties.php
+++ b/includes/header_properties.php
@@ -14,12 +14,24 @@
                 </div>
             </div>
             <div class="header-props__center">
-            <div class="header-props__search-bar">
-                <input type="text" placeholder="Buscar..." class="header-props__search-input">
-                <button class="header-props__search-button">
-                <img src="assets/images/iconcaracteristic/search-icon.png" alt="Buscar">
-                </button>
-            </div>
+                <form class="header-props__search-bar" action="properties.php" method="get" role="search" id="props-search-form">
+                    <input
+                        type="text"
+                        name="search"
+                        placeholder="Buscar..."
+                        value="<?php echo isset($search) ? htmlspecialchars($search) : ''; ?>"
+                        class="header-props__search-input">
+                    <input type="hidden" name="listing_type" value="<?php echo htmlspecialchars($listing_type ?? 'venta'); ?>">
+                    <?php if (!empty($category)): ?>
+                        <input type="hidden" name="category" value="<?php echo htmlspecialchars($category); ?>">
+                    <?php endif; ?>
+                    <?php if (!empty($location)): ?>
+                        <input type="hidden" name="location" value="<?php echo htmlspecialchars($location); ?>">
+                    <?php endif; ?>
+                    <button class="header-props__search-button" type="submit">
+                        <img src="assets/images/iconcaracteristic/search-icon.png" alt="Buscar">
+                    </button>
+                </form>
             </div>
         </div>
     </div>
@@ -31,19 +43,19 @@
                     <a href="?listing_type=renta" class="header-props__filter-button <?php echo (isset($_GET['listing_type']) && $_GET['listing_type'] == 'renta') ? 'header-props__filter-button--active' : ''; ?>">Rentar</a>
                 </div>
                 <div class="header-props__filter-group">
-                    <select class="header-props__filter-select" onchange="location = this.value;">
-                        <option value="properties.php">Tipo de propiedad</option>
-                        <option value="properties.php?category=casas">Casa</option>
-                        <option value="properties.php?category=departamentos">Departamento</option>
-                        <option value="properties.php?category=terrenos">Terreno</option>
+                    <select id="category-select" class="header-props__filter-select" name="category">
+                        <option value="">Tipo de propiedad</option>
+                        <option value="casas" <?php echo ($category === 'casas') ? 'selected' : ''; ?>>Casa</option>
+                        <option value="departamentos" <?php echo ($category === 'departamentos') ? 'selected' : ''; ?>>Departamento</option>
+                        <option value="terrenos" <?php echo ($category === 'terrenos') ? 'selected' : ''; ?>>Terreno</option>
                     </select>
                 </div>
                 <div class="header-props__filter-group">
-                    <select class="header-props__filter-select" onchange="location = this.value;">
-                        <option value="properties.php">Ubicación</option>
-                        <option value="properties.php?location=Benito Juárez">Cancún</option>
-                        <option value="properties.php?location=Playa del Carmen">Playa del Carmen</option>
-                        <option value="properties.php?location=Tulum">Tulum</option>
+                    <select id="location-select" class="header-props__filter-select" name="location">
+                        <option value="">Ubicación</option>
+                        <option value="Benito Juárez" <?php echo ($location === 'Benito Juárez') ? 'selected' : ''; ?>>Cancún</option>
+                        <option value="Playa del Carmen" <?php echo ($location === 'Playa del Carmen') ? 'selected' : ''; ?>>Playa del Carmen</option>
+                        <option value="Tulum" <?php echo ($location === 'Tulum') ? 'selected' : ''; ?>>Tulum</option>
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- make the search bar a form so filters persist
- support `.header-props__toggle` in JS mobile menu logic
- enhance responsive header design
- auto-submit filters from select dropdowns

## Testing
- `php -l includes/header_properties.php`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ac019cdfc83208912d5a72495f3a6