### PR TITLE
Add dynamic price filter to properties header

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3445,12 +3445,15 @@ body:not(.home) header .header__toggle-line {
 /* Parte inferior del header */
 .header-properties__bottom {
     padding: 10px 20px;
+    background-color: #f8f9fa;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .header-properties__filters-form {
     display: flex;
     align-items: center;
     gap: 15px;
+    flex-wrap: wrap;
 }
 
 /* Botones Comprar / Rentar */
@@ -3494,6 +3497,71 @@ body:not(.home) header .header__toggle-line {
 /* Grupo de filtros */
 .header-properties__filter-group {
     flex-shrink: 0; /* Evita que los filtros se encojan */
+}
+
+.header-properties__filter-group--price {
+    position: relative;
+}
+
+.header-properties__price-toggle {
+    padding: 10px 15px;
+    font-size: 15px;
+    border: 1px solid #dfe4ea;
+    border-radius: 8px;
+    background-color: #fff;
+    cursor: pointer;
+    min-width: 120px;
+}
+
+.header-properties__price-dropdown {
+    position: absolute;
+    top: 110%;
+    left: 0;
+    background-color: #fff;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    border-radius: 8px;
+    padding: 15px;
+    display: none;
+    width: 250px;
+    z-index: 10;
+}
+
+.header-properties__price-dropdown--active {
+    display: block;
+}
+
+.header-properties__price-inputs {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.header-properties__price-input {
+    flex: 1;
+    padding: 5px;
+    border: 1px solid #dfe4ea;
+    border-radius: 4px;
+}
+
+.header-properties__price-sliders {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.header-properties__price-slider {
+    width: 100%;
+}
+
+.header-properties__price-apply {
+    width: 100%;
+    padding: 8px;
+    background-color: #2c3e50;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
 }
 
 .header-properties__select {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -255,4 +255,56 @@ if (initialTab) {
 
     setupCategoryFilter('destacadas-showcase');
     setupCategoryFilter('renta-showcase');
+
+    // ===============================
+    // === LÓGICA DEL FILTRO DE PRECIOS ===
+    // ===============================
+    const priceToggle = document.querySelector('.header-properties__price-toggle');
+    const priceDropdown = document.querySelector('.header-properties__price-dropdown');
+    const minRange = document.getElementById('price-min-range');
+    const maxRange = document.getElementById('price-max-range');
+    const minInput = document.getElementById('min-price-input');
+    const maxInput = document.getElementById('max-price-input');
+
+    if (priceToggle && priceDropdown && minRange && maxRange && minInput && maxInput) {
+        const syncFromRanges = () => {
+            let min = parseInt(minRange.value, 10);
+            let max = parseInt(maxRange.value, 10);
+            if (min > max) {
+                [min, max] = [max, min];
+            }
+            minRange.value = min;
+            maxRange.value = max;
+            minInput.value = min;
+            maxInput.value = max;
+        };
+
+        const syncFromInputs = () => {
+            let min = parseInt(minInput.value, 10) || 0;
+            let max = parseInt(maxInput.value, 10) || 0;
+            if (min > max) {
+                max = min;
+                maxInput.value = max;
+            }
+            minRange.value = min;
+            maxRange.value = max;
+        };
+
+        priceToggle.addEventListener('click', () => {
+            priceDropdown.classList.toggle('header-properties__price-dropdown--active');
+        });
+
+        minRange.addEventListener('input', syncFromRanges);
+        maxRange.addEventListener('input', syncFromRanges);
+        minInput.addEventListener('input', syncFromInputs);
+        maxInput.addEventListener('input', syncFromInputs);
+
+        document.addEventListener('click', (e) => {
+            if (!priceDropdown.contains(e.target) && !priceToggle.contains(e.target)) {
+                priceDropdown.classList.remove('header-properties__price-dropdown--active');
+            }
+        });
+
+        syncFromInputs();
+    }
 });

--- a/includes/header_properties.php
+++ b/includes/header_properties.php
@@ -13,6 +13,8 @@ $listing_type = isset($_GET['listing_type']) ? $_GET['listing_type'] : 'venta';
 $category = isset($_GET['category']) ? $_GET['category'] : '';
 $location = isset($_GET['location']) ? $_GET['location'] : '';
 $search = isset($_GET['search']) ? trim($_GET['search']) : '';
+$min_price = isset($_GET['min_price']) ? $_GET['min_price'] : '';
+$max_price = isset($_GET['max_price']) ? $_GET['max_price'] : '';
 
 // Obtener todas las ubicaciones (municipios) de la base de datos para el dropdown
 $locations_stmt = $pdo->query("SELECT DISTINCT location FROM properties WHERE status = 'disponible' ORDER BY location ASC");
@@ -33,6 +35,10 @@ $available_locations = $locations_stmt->fetchAll(PDO::FETCH_COLUMN);
         <div class="header-properties__search-container">
             <form action="properties.php" method="GET" class="header-properties__search-form">
                 <input type="hidden" name="listing_type" value="<?php echo htmlspecialchars($listing_type); ?>">
+                <input type="hidden" name="category" value="<?php echo htmlspecialchars($category); ?>">
+                <input type="hidden" name="location" value="<?php echo htmlspecialchars($location); ?>">
+                <input type="hidden" name="min_price" value="<?php echo htmlspecialchars($min_price); ?>">
+                <input type="hidden" name="max_price" value="<?php echo htmlspecialchars($max_price); ?>">
                 <input type="text" name="search" class="header-properties__search-input" placeholder="Buscar por título, descripción..." value="<?php echo htmlspecialchars($search); ?>">
                 <button type="submit" class="header-properties__search-button">
                     <img src="assets/images/iconcaracteristic/search-icon.png" alt="Buscar">
@@ -46,8 +52,8 @@ $available_locations = $locations_stmt->fetchAll(PDO::FETCH_COLUMN);
     <div class="header-properties__bottom">
         <form action="properties.php" method="GET" class="header-properties__filters-form">
             <div class="header-properties__listing-type">
-                <a href="?listing_type=venta&search=<?php echo urlencode($search); ?>&category=<?php echo urlencode($category); ?>&location=<?php echo urlencode($location); ?>" class="header-properties__button <?php echo $listing_type === 'venta' ? 'active' : ''; ?>">Comprar</a>
-                <a href="?listing_type=renta&search=<?php echo urlencode($search); ?>&category=<?php echo urlencode($category); ?>&location=<?php echo urlencode($location); ?>" class="header-properties__button <?php echo $listing_type === 'renta' ? 'active' : ''; ?>">Rentar</a>
+                <a href="?listing_type=venta&search=<?php echo urlencode($search); ?>&category=<?php echo urlencode($category); ?>&location=<?php echo urlencode($location); ?>&min_price=<?php echo urlencode($min_price); ?>&max_price=<?php echo urlencode($max_price); ?>" class="header-properties__button <?php echo $listing_type === 'venta' ? 'active' : ''; ?>">Comprar</a>
+                <a href="?listing_type=renta&search=<?php echo urlencode($search); ?>&category=<?php echo urlencode($category); ?>&location=<?php echo urlencode($location); ?>&min_price=<?php echo urlencode($min_price); ?>&max_price=<?php echo urlencode($max_price); ?>" class="header-properties__button <?php echo $listing_type === 'renta' ? 'active' : ''; ?>">Rentar</a>
             </div>
 
             <div class="header-properties__filters-scroll">
@@ -72,6 +78,21 @@ $available_locations = $locations_stmt->fetchAll(PDO::FETCH_COLUMN);
                             </option>
                         <?php endforeach; ?>
                     </select>
+                </div>
+
+                <div class="header-properties__filter-group header-properties__filter-group--price">
+                    <button type="button" class="header-properties__price-toggle">Precios</button>
+                    <div class="header-properties__price-dropdown">
+                        <div class="header-properties__price-inputs">
+                            <input type="number" name="min_price" id="min-price-input" class="header-properties__price-input" placeholder="Mín" value="<?php echo htmlspecialchars($min_price); ?>" min="0" step="1000">
+                            <input type="number" name="max_price" id="max-price-input" class="header-properties__price-input" placeholder="Máx" value="<?php echo htmlspecialchars($max_price); ?>" min="0" step="1000">
+                        </div>
+                        <div class="header-properties__price-sliders">
+                            <input type="range" id="price-min-range" class="header-properties__price-slider" min="0" max="10000000" step="1000" value="<?php echo $min_price !== '' ? htmlspecialchars($min_price) : 0; ?>">
+                            <input type="range" id="price-max-range" class="header-properties__price-slider" min="0" max="10000000" step="1000" value="<?php echo $max_price !== '' ? htmlspecialchars($max_price) : 10000000; ?>">
+                        </div>
+                        <button type="submit" class="header-properties__price-apply">Aplicar</button>
+                    </div>
                 </div>
             </div>
             <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">

--- a/properties.php
+++ b/properties.php
@@ -6,6 +6,8 @@ $listing_type = isset($_GET['listing_type']) ? $_GET['listing_type'] : 'venta';
 $search = isset($_GET['search']) ? trim($_GET['search']) : '';
 $category = isset($_GET['category']) ? $_GET['category'] : '';
 $location = isset($_GET['location']) ? $_GET['location'] : '';
+$min_price = isset($_GET['min_price']) && $_GET['min_price'] !== '' ? (float)$_GET['min_price'] : '';
+$max_price = isset($_GET['max_price']) && $_GET['max_price'] !== '' ? (float)$_GET['max_price'] : '';
 
 // Construir la consulta SQL base
 $sql = "SELECT * FROM properties WHERE status = 'disponible' AND listing_type = :listing_type";
@@ -23,6 +25,14 @@ if ($category) {
 if ($location) {
     $sql .= " AND location = :location";
     $params[':location'] = $location;
+}
+if ($min_price !== '') {
+    $sql .= " AND price >= :min_price";
+    $params[':min_price'] = $min_price;
+}
+if ($max_price !== '') {
+    $sql .= " AND price <= :max_price";
+    $params[':max_price'] = $max_price;
 }
 
 $sql .= " ORDER BY created_at DESC";


### PR DESCRIPTION
## Summary
- add responsive price dropdown with range sliders to property header
- style header bottom and integrate BEM classes
- allow backend filtering by price range

## Testing
- `php -l includes/header_properties.php`
- `php -l properties.php`


------
https://chatgpt.com/codex/tasks/task_e_688e4a8888f08320adb72090eae0b4c3