### PR TITLE
Add API news endpoint and render home news section

### DIFF
--- a/backend/controllers/newsController.js
+++ b/backend/controllers/newsController.js
@@ -1,0 +1,31 @@
+// backend/controllers/newsController.js
+
+const db = require('../config/db');
+
+// Obtener noticias para la página principal
+exports.getNews = async (req, res) => {
+  const limit = parseInt(req.query.limit, 10);
+  const hasLimit = Number.isInteger(limit) && limit > 0;
+
+  const baseQuery = `
+    SELECT id, title, date, images, information, sources, is_main, display_order
+    FROM news
+    ORDER BY display_order ASC, date DESC
+  `.trim();
+
+  try {
+    const [rows] = hasLimit
+      ? await db.query(`${baseQuery} LIMIT ?`, [limit])
+      : await db.query(baseQuery);
+
+    const normalizedRows = rows.map((news) => ({
+      ...news,
+      images: typeof news.images === 'string' ? news.images : JSON.stringify(news.images || []),
+    }));
+
+    res.json(normalizedRows);
+  } catch (error) {
+    console.error('Error al obtener las noticias:', error);
+    res.status(500).json({ message: 'Error en el servidor al obtener las noticias' });
+  }
+};

--- a/backend/routes/newsRoutes.js
+++ b/backend/routes/newsRoutes.js
@@ -1,0 +1,10 @@
+// backend/routes/newsRoutes.js
+
+const express = require('express');
+const router = express.Router();
+const newsController = require('../controllers/newsController');
+
+// Ruta para obtener las noticias
+router.get('/news', newsController.getNews);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,12 +20,14 @@ const authRoutes = require('./routes/authRoutes');
 const sellerRoutes = require('./routes/sellerRoutes');
 const adminRoutes = require('./routes/adminRoutes');
 const heroRoutes = require('./routes/heroRoutes');
+const newsRoutes = require('./routes/newsRoutes');
 
 app.use('/api/properties', propertiesRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/seller', sellerRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api', heroRoutes);
+app.use('/api', newsRoutes);
 
 // Una ruta de prueba
 app.get('/api', (req, res) => {


### PR DESCRIPTION
## Summary
- add a dedicated controller and route to expose ordered news data with optional limits
- register the news API in the express server alongside existing routes
- enhance the home page script to safely render news cards with fallbacks using the new endpoint

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9b14d89508320b6ff37bef0ed663e