### PR TITLE
Fix property showcase category filter

### DIFF
--- a/frontend/assets/js/app.js
+++ b/frontend/assets/js/app.js
@@ -105,16 +105,27 @@ document.addEventListener('DOMContentLoaded', () => {
             const properties = await response.json();
 
             const carousel = document.querySelector(carouselId);
+            if (!carousel) {
+                console.warn(`No se encontró el carrusel con el selector ${carouselId}`);
+                return;
+            }
+
             carousel.innerHTML = ''; // Limpiar el carrusel
 
             properties.forEach(prop => {
                 const price = new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(prop.price);
                 const priceSuffix = listingType === 'renta' ? ' / Mes' : ' MXN';
 
+                const rawCategory = typeof prop.category === 'string' ? prop.category : '';
+                const normalizedCategory = rawCategory.toLowerCase();
+                const displayCategory = rawCategory
+                    ? rawCategory.charAt(0).toUpperCase() + rawCategory.slice(1).toLowerCase()
+                    : '';
+
                 carousel.innerHTML += `
-                    <div class="property-showcase__slide-card" data-category="${prop.category}">
+                    <div class="property-showcase__slide-card" data-category="${normalizedCategory}">
                         <a href="property_detail.php?id=${prop.id}">
-                            <div class="property-showcase__category-badge">${prop.category.charAt(0).toUpperCase() + prop.category.slice(1)}</div>
+                            <div class="property-showcase__category-badge">${displayCategory}</div>
                             <img src="${prop.main_image}" alt="${prop.title}">
                             <div class="property-showcase__slide-card-info">
                                 <p class="price">${price}${priceSuffix}</p>
@@ -123,6 +134,15 @@ document.addEventListener('DOMContentLoaded', () => {
                         </a>
                     </div>`;
             });
+
+            const parentShowcase = carousel.closest('.property-showcase');
+            document.dispatchEvent(new CustomEvent('propertiesLoaded', {
+                detail: {
+                    listingType,
+                    carouselId,
+                    showcaseId: parentShowcase ? parentShowcase.id : null,
+                }
+            }));
         } catch (error) {
             console.error(`Error al cargar propiedades en ${listingType}:`, error);
         }

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -238,7 +238,21 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!showcase) return;
 
         const filterLinks = showcase.querySelectorAll('.property-showcase__filter-link');
-        const propertyCards = showcase.querySelectorAll('.property-showcase__slide-card');
+
+        const applyFilter = (category) => {
+            const normalizedCategory = (category || '').toLowerCase();
+            const propertyCards = showcase.querySelectorAll('.property-showcase__slide-card');
+
+            propertyCards.forEach(card => {
+                const cardCategory = (card.dataset.category || '').toLowerCase();
+
+                if (normalizedCategory === 'all' || normalizedCategory === '' || cardCategory === normalizedCategory) {
+                    card.classList.remove('property-showcase__slide-card--hidden');
+                } else {
+                    card.classList.add('property-showcase__slide-card--hidden');
+                }
+            });
+        };
 
         filterLinks.forEach(link => {
             link.addEventListener('click', (e) => {
@@ -247,17 +261,38 @@ document.addEventListener('DOMContentLoaded', () => {
                 filterLinks.forEach(l => l.classList.remove('active'));
                 link.classList.add('active');
 
-                const category = link.dataset.category;
-
-                propertyCards.forEach(card => {
-                    if (category === 'all' || card.dataset.category === category) {
-                        card.classList.remove('property-showcase__slide-card--hidden');
-                    } else {
-                        card.classList.add('property-showcase__slide-card--hidden');
-                    }
-                });
+                applyFilter(link.dataset.category);
             });
         });
+
+        const handlePropertiesLoaded = (event) => {
+            const { carouselId, showcaseId: loadedShowcaseId } = event.detail || {};
+
+            let targetShowcaseId = loadedShowcaseId || null;
+            if (!targetShowcaseId && carouselId) {
+                const carousel = document.querySelector(carouselId);
+                const parentShowcase = carousel ? carousel.closest('.property-showcase') : null;
+                targetShowcaseId = parentShowcase ? parentShowcase.id : null;
+            }
+
+            if (targetShowcaseId !== showcaseId) {
+                return;
+            }
+
+            const activeLink = showcase.querySelector('.property-showcase__filter-link.active')
+                || showcase.querySelector('.property-showcase__filter-link[data-category="all"]');
+
+            if (activeLink) {
+                applyFilter(activeLink.dataset.category);
+            }
+        };
+
+        document.addEventListener('propertiesLoaded', handlePropertiesLoaded);
+
+        const initialActiveLink = showcase.querySelector('.property-showcase__filter-link.active');
+        if (initialActiveLink) {
+            applyFilter(initialActiveLink.dataset.category);
+        }
     }
 
     setupCategoryFilter('destacadas-showcase');


### PR DESCRIPTION
## Summary
- normalize categories when rendering property cards and emit an event after dynamic loading
- update the category filter logic to work with dynamically injected cards and reapply the active filter when new data arrives

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9bd42a3348320a1ae8522082fdf3f