### PR TITLE
Fix property price rendering

### DIFF
--- a/frontend/assets/js/properties.js
+++ b/frontend/assets/js/properties.js
@@ -261,8 +261,9 @@
                     ? capitalize(property.category)
                     : '';
                 const locationText = property.location || '';
-                const price = typeof property.price === 'number'
-                    ? new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(property.price)
+                const priceValue = Number(property.price);
+                const price = Number.isFinite(priceValue)
+                    ? currencyFormatter.format(priceValue)
                     : '';
                 card.innerHTML = `
                     <a href="property_detail.php?id=${propertyId}" class="property-card__link">
@@ -281,7 +282,7 @@
                             </p>
                         </div>
                         <div class="property-card__footer">
-                            <p class="property-card__price">${price} MXN</p>
+                            <p class="property-card__price">${price}</p>
                             <span class="property-card__details-button">Ver detalles &rarr;</span>
                         </div>
                     </a>


### PR DESCRIPTION
## Summary
- format property prices using the existing currency formatter so string values from the API render correctly
- remove the redundant "MXN" suffix after formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca2f8232e083209a2f52efec46ca6c