### PR TITLE
Convert property detail page to HTML and fetch data from API

### DIFF
--- a/frontend/assets/js/app.js
+++ b/frontend/assets/js/app.js
@@ -124,7 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 carousel.innerHTML += `
                     <div class="property-showcase__slide-card" data-category="${normalizedCategory}">
-                        <a href="property_detail.php?id=${prop.id}">
+                        <a href="property_detail.html?id=${prop.id}">
                             <div class="property-showcase__category-badge">${displayCategory}</div>
                             <img src="${prop.main_image}" alt="${prop.title}">
                             <div class="property-showcase__slide-card-info">

--- a/frontend/assets/js/properties.js
+++ b/frontend/assets/js/properties.js
@@ -266,7 +266,7 @@
                     ? currencyFormatter.format(priceValue)
                     : '';
                 card.innerHTML = `
-                    <a href="property_detail.php?id=${propertyId}" class="property-card__link">
+                    <a href="property_detail.html?id=${propertyId}" class="property-card__link">
                         <div class="property-card__image-container">
                             <img class="property-card__image" src="${escapeHtml(imageSrc)}" alt="${escapeHtml(property.title || 'Propiedad')}">
                             <div class="property-card__badge property-card__badge--listing">${listingText}</div>

--- a/frontend/assets/js/property-detail.js
+++ b/frontend/assets/js/property-detail.js
@@ -1,0 +1,496 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!document.body.classList.contains('property-detail-page')) {
+            return;
+        }
+
+        const API_BASE_URL = 'http://localhost:3000/api';
+        const PLACEHOLDER_IMAGE = 'assets/images/hero/placeholder.jpg';
+        const currencyFormatter = new Intl.NumberFormat('es-MX', {
+            style: 'currency',
+            currency: 'MXN',
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        });
+
+        const urlParams = new URLSearchParams(window.location.search);
+        const propertyIdParam = urlParams.get('id');
+        const propertyId = Number.parseInt(propertyIdParam ?? '', 10);
+
+        const contentContainer = document.getElementById('property-content');
+        const gallerySection = document.getElementById('gallery-section');
+        const galleryLayout = document.getElementById('gallery-layout');
+        const breadcrumbListing = document.getElementById('breadcrumb-listing');
+        const breadcrumbLocation = document.getElementById('breadcrumb-location');
+        const breadcrumbCategory = document.getElementById('breadcrumb-category');
+        const propertyTitleEl = document.getElementById('property-title');
+        const propertyLocationEl = document.getElementById('property-location');
+        const propertyPriceEl = document.getElementById('property-price');
+        const propertyDescriptionEl = document.getElementById('property-description');
+        const propertyFeaturesSection = document.getElementById('property-features-section');
+        const propertyFeaturesList = document.getElementById('property-features');
+        const propertyCodeEl = document.getElementById('property-code');
+        const mapSection = document.getElementById('property-map-section');
+        const mapFrame = document.getElementById('property-map-frame');
+        const similarSection = document.getElementById('similar-section');
+        const similarGrid = document.getElementById('similar-grid');
+        const similarCarouselWrapper = document.getElementById('similar-carousel-wrapper');
+        const footerYear = document.getElementById('footer-year');
+        const errorContainer = document.getElementById('property-error');
+        const errorMessageEl = document.getElementById('property-error-message');
+        const contactPropertyId = document.getElementById('contact-property-id');
+        const contactPropertyTitle = document.getElementById('contact-property-title');
+        const contactMessage = document.getElementById('contact-message');
+        const contactWhatsapp = document.getElementById('contact-whatsapp');
+
+        updateFooterYear(footerYear);
+
+        if (contentContainer) {
+            contentContainer.hidden = true;
+        }
+
+        if (!Number.isInteger(propertyId) || propertyId <= 0) {
+            showError('Propiedad no encontrada.', contentContainer, errorContainer, errorMessageEl, similarSection);
+            return;
+        }
+
+        fetchProperty(propertyId);
+
+        async function fetchProperty(id) {
+            try {
+                const response = await fetch(`${API_BASE_URL}/properties/${id}`);
+                if (!response.ok) {
+                    throw new Error('No se encontró la propiedad');
+                }
+                const data = await response.json();
+                renderProperty(data);
+            } catch (error) {
+                console.error('Error al cargar la propiedad:', error);
+                showError('No se pudo cargar la propiedad solicitada.', contentContainer, errorContainer, errorMessageEl, similarSection);
+            }
+        }
+
+        function renderProperty(data) {
+            const property = data?.property ?? null;
+            const images = Array.isArray(data?.images) ? data.images : [];
+            const similarProperties = Array.isArray(data?.similarProperties) ? data.similarProperties : [];
+
+            if (!property) {
+                showError('Propiedad no encontrada.', contentContainer, errorContainer, errorMessageEl, similarSection);
+                return;
+            }
+
+            const title = sanitizeString(property.title) || 'Propiedad sin título';
+            document.title = `${title} - DOMABLY`;
+
+            if (propertyTitleEl) {
+                propertyTitleEl.textContent = title;
+            }
+
+            if (propertyLocationEl) {
+                const locationText = sanitizeString(property.location) || 'Ubicación no disponible';
+                propertyLocationEl.textContent = locationText;
+            }
+
+            if (propertyPriceEl) {
+                if (property.price !== null && property.price !== undefined && property.price !== '') {
+                    const formattedPrice = currencyFormatter.format(Number(property.price));
+                    const listingType = sanitizeString(property.listing_type).toLowerCase();
+                    let priceHtml = `${formattedPrice} MXN`;
+                    if (listingType === 'renta') {
+                        priceHtml += ' <span class="property-info__price-period">/ Mes</span>';
+                    }
+                    propertyPriceEl.innerHTML = priceHtml;
+                } else {
+                    propertyPriceEl.textContent = 'Precio no disponible';
+                }
+            }
+
+            if (propertyDescriptionEl) {
+                const descriptionText = sanitizeString(property.description) || 'No hay descripción disponible.';
+                propertyDescriptionEl.innerHTML = formatMultiline(descriptionText);
+            }
+
+            const parsedFeatures = parseFeatures(property.features);
+            renderFeatures(property.category, parsedFeatures, propertyFeaturesSection, propertyFeaturesList);
+
+            if (propertyCodeEl) {
+                propertyCodeEl.textContent = property.id ?? '';
+            }
+
+            if (contactPropertyId) {
+                contactPropertyId.value = property.id ?? '';
+            }
+
+            if (contactPropertyTitle) {
+                contactPropertyTitle.value = title;
+            }
+
+            if (contactMessage) {
+                contactMessage.value = `¡Hola! Quiero que se comuniquen conmigo por este inmueble: ${title}. Gracias.`;
+            }
+
+            if (contactWhatsapp) {
+                const whatsappText = `Estoy interesado en la propiedad: ${title}`;
+                contactWhatsapp.href = `https://wa.me/5219997632818?text=${encodeURIComponent(whatsappText)}`;
+            }
+
+            renderBreadcrumbs(property, breadcrumbListing, breadcrumbLocation, breadcrumbCategory);
+            renderGallery(images, title, gallerySection, galleryLayout);
+            renderMap(property, mapSection, mapFrame);
+            renderSimilarProperties(similarProperties, similarSection, similarGrid, similarCarouselWrapper, currencyFormatter, PLACEHOLDER_IMAGE);
+
+            if (contentContainer) {
+                contentContainer.hidden = false;
+            }
+
+            if (errorContainer) {
+                errorContainer.hidden = true;
+            }
+        }
+    });
+
+    function renderBreadcrumbs(property, listingEl, locationEl, categoryEl) {
+        const listingType = sanitizeString(property?.listing_type).toLowerCase();
+        const listingLabel = listingType ? capitalizeFirst(listingType) : 'Propiedades';
+        const location = sanitizeString(property?.location);
+        const category = sanitizeString(property?.category);
+
+        if (listingEl) {
+            listingEl.textContent = listingLabel;
+            listingEl.href = listingType ? `properties.html?listing_type=${encodeURIComponent(listingType)}` : 'properties.html';
+        }
+
+        if (locationEl) {
+            locationEl.textContent = location || 'Ubicación';
+            locationEl.href = location ? `properties.html?location=${encodeURIComponent(location)}` : 'properties.html';
+        }
+
+        if (categoryEl) {
+            const categoryLower = category ? category.toLowerCase() : '';
+            categoryEl.textContent = category ? capitalizeFirst(categoryLower) : 'Categoría';
+            categoryEl.href = categoryLower ? `properties.html?category=${encodeURIComponent(categoryLower)}` : 'properties.html';
+        }
+    }
+
+    function renderGallery(images, title, gallerySection, galleryLayout) {
+        if (!gallerySection || !galleryLayout) {
+            return;
+        }
+
+        galleryLayout.innerHTML = '';
+
+        if (!Array.isArray(images) || images.length === 0) {
+            gallerySection.hidden = true;
+            window.propertyImages = [];
+            return;
+        }
+
+        const mainGalleryImages = images.slice(0, 5);
+        const totalImages = images.length;
+
+        mainGalleryImages.forEach((imageSrc, index) => {
+            const item = document.createElement('div');
+            item.className = `gallery__item ${index === 0 ? 'gallery__item--large' : 'gallery__item--thumb'}`;
+            item.dataset.index = String(index);
+
+            const img = document.createElement('img');
+            img.src = imageSrc;
+            img.alt = `Vista ${index + 1} de ${title}`;
+            img.className = 'gallery__image';
+            item.appendChild(img);
+
+            if (index === mainGalleryImages.length - 1 && totalImages > mainGalleryImages.length) {
+                const overlay = document.createElement('div');
+                overlay.className = 'gallery__overlay';
+                overlay.innerHTML = `
+                    <div class="gallery__photo-count">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-camera"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
+                        <span>${totalImages} Fotos</span>
+                    </div>`;
+                item.appendChild(overlay);
+            }
+
+            galleryLayout.appendChild(item);
+        });
+
+        gallerySection.hidden = false;
+        window.propertyImages = [...images];
+        document.dispatchEvent(new CustomEvent('propertyImagesLoaded', { detail: { images: [...images] } }));
+    }
+
+    function renderMap(property, mapSection, mapFrame) {
+        if (!mapSection || !mapFrame) {
+            return;
+        }
+
+        const latitude = parseFloat(property?.latitude);
+        const longitude = parseFloat(property?.longitude);
+
+        if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
+            const coords = `${latitude},${longitude}`;
+            mapFrame.src = `https://maps.google.com/maps?q=${encodeURIComponent(coords)}&t=&z=15&ie=UTF8&iwloc=&output=embed`;
+            mapSection.hidden = false;
+        } else {
+            mapFrame.src = '';
+            mapSection.hidden = true;
+        }
+    }
+
+    function renderSimilarProperties(similarProperties, similarSection, similarGrid, carouselWrapper, currencyFormatter, placeholderImage) {
+        if (!similarSection || !similarGrid || !carouselWrapper) {
+            return;
+        }
+
+        similarGrid.innerHTML = '';
+
+        if (!Array.isArray(similarProperties) || similarProperties.length === 0) {
+            similarSection.hidden = true;
+            return;
+        }
+
+        similarProperties.forEach((property) => {
+            const card = document.createElement('div');
+            card.className = 'property-card';
+
+            const link = document.createElement('a');
+            link.href = `property_detail.html?id=${property.id}`;
+            link.className = 'property-card__link';
+
+            const imageContainer = document.createElement('div');
+            imageContainer.className = 'property-card__image-container';
+
+            const image = document.createElement('img');
+            image.className = 'property-card__image';
+            image.src = typeof property.main_image === 'string' && property.main_image.trim().length > 0 ? property.main_image : placeholderImage;
+            image.alt = sanitizeString(property.title) || 'Propiedad similar';
+            imageContainer.appendChild(image);
+
+            const listingBadge = document.createElement('div');
+            listingBadge.className = 'property-card__badge property-card__badge--listing';
+            listingBadge.textContent = capitalizeFirst(sanitizeString(property.listing_type).toLowerCase());
+            imageContainer.appendChild(listingBadge);
+
+            const categoryBadge = document.createElement('div');
+            categoryBadge.className = 'property-card__badge property-card__badge--category';
+            categoryBadge.textContent = capitalizeFirst(sanitizeString(property.category).toLowerCase());
+            imageContainer.appendChild(categoryBadge);
+
+            const content = document.createElement('div');
+            content.className = 'property-card__content';
+            const title = document.createElement('h3');
+            title.className = 'property-card__title';
+            title.textContent = sanitizeString(property.title) || 'Propiedad';
+            content.appendChild(title);
+
+            const footer = document.createElement('div');
+            footer.className = 'property-card__footer';
+            const price = document.createElement('p');
+            price.className = 'property-card__price';
+            if (property.price !== null && property.price !== undefined && property.price !== '') {
+                price.textContent = `${currencyFormatter.format(Number(property.price))} MXN`;
+            } else {
+                price.textContent = 'Consultar precio';
+            }
+            footer.appendChild(price);
+
+            link.appendChild(imageContainer);
+            link.appendChild(content);
+            link.appendChild(footer);
+            card.appendChild(link);
+            similarGrid.appendChild(card);
+        });
+
+        similarSection.hidden = false;
+        carouselWrapper.scrollLeft = 0;
+
+        const prevBtn = document.getElementById('similar-prev');
+        const nextBtn = document.getElementById('similar-next');
+        const firstCard = carouselWrapper.querySelector('.property-card');
+
+        if (!firstCard || !prevBtn || !nextBtn) {
+            return;
+        }
+
+        const scrollAmount = firstCard.offsetWidth + 30;
+        prevBtn.onclick = () => {
+            carouselWrapper.scrollLeft -= scrollAmount;
+        };
+        nextBtn.onclick = () => {
+            carouselWrapper.scrollLeft += scrollAmount;
+        };
+    }
+
+    function parseFeatures(features) {
+        if (!features) {
+            return {};
+        }
+        if (typeof features === 'string') {
+            try {
+                const parsed = JSON.parse(features);
+                return typeof parsed === 'object' && parsed !== null ? parsed : {};
+            } catch (error) {
+                return {};
+            }
+        }
+        if (typeof features === 'object') {
+            return features;
+        }
+        return {};
+    }
+
+    function renderFeatures(category, features, sectionEl, listEl) {
+        if (!sectionEl || !listEl) {
+            return;
+        }
+
+        listEl.innerHTML = '';
+        const normalizedCategory = sanitizeString(category).toLowerCase();
+        const featureItems = [];
+
+        const addFeature = (condition, icon, alt, label) => {
+            if (!condition) {
+                return;
+            }
+            featureItems.push({ icon, alt, label });
+        };
+
+        const hasValue = (value) => {
+            if (value === null || value === undefined) {
+                return false;
+            }
+            const stringValue = String(value).trim();
+            return stringValue.length > 0 && stringValue !== '0';
+        };
+
+        const isAffirmative = (value) => {
+            if (typeof value !== 'string') {
+                return false;
+            }
+            const normalized = value.trim().toLowerCase();
+            return normalized === 'sí' || normalized === 'si' || normalized === 'yes';
+        };
+
+        const featuresData = features ?? {};
+
+        if (normalizedCategory === 'casas') {
+            addFeature(hasValue(featuresData.recamaras), 'assets/images/iconcaracteristic/icon_bed.png', 'Recámaras', `${featuresData.recamaras} Recámaras`);
+            addFeature(hasValue(featuresData.banos), 'assets/images/iconcaracteristic/icon_bath.png', 'Baños', `${featuresData.banos} Baños`);
+            addFeature(hasValue(featuresData.estacionamientos), 'assets/images/iconcaracteristic/icon_parking.png', 'Estacionamientos', `${featuresData.estacionamientos} Estacionamientos`);
+            addFeature(hasValue(featuresData.superficie_construida), 'assets/images/iconcaracteristic/icon_built_area.png', 'Construcción', `${featuresData.superficie_construida} m² Construidos`);
+            addFeature(hasValue(featuresData.superficie_total), 'assets/images/iconcaracteristic/icon_total_area.png', 'Terreno', `${featuresData.superficie_total} m² Terreno`);
+            addFeature(hasValue(featuresData.niveles), 'assets/images/iconcaracteristic/icon_floors.png', 'Niveles', `${featuresData.niveles} Niveles`);
+            addFeature(isAffirmative(featuresData.terraza), 'assets/images/iconcaracteristic/icon_terrace.png', 'Terraza', 'Terraza');
+            addFeature(isAffirmative(featuresData.alberca), 'assets/images/iconcaracteristic/icon_pool.png', 'Alberca', 'Alberca');
+            addFeature(isAffirmative(featuresData.amueblada), 'assets/images/iconcaracteristic/icon_furniture.png', 'Amueblada', 'Amueblada');
+        } else if (normalizedCategory === 'departamentos') {
+            addFeature(hasValue(featuresData.recamaras), 'assets/images/iconcaracteristic/icon_bed.png', 'Recámaras', `${featuresData.recamaras} Recámaras`);
+            addFeature(hasValue(featuresData.banos), 'assets/images/iconcaracteristic/icon_bath.png', 'Baños', `${featuresData.banos} Baños`);
+            addFeature(hasValue(featuresData.estacionamientos), 'assets/images/iconcaracteristic/icon_parking.png', 'Estacionamientos', `${featuresData.estacionamientos} Estacionamientos`);
+            addFeature(hasValue(featuresData.superficie_total), 'assets/images/iconcaracteristic/icon_built_area.png', 'Superficie total', `${featuresData.superficie_total} m² Totales`);
+            addFeature(hasValue(featuresData.piso), 'assets/images/iconcaracteristic/icon_floors.png', 'Piso', `Piso ${featuresData.piso}`);
+            addFeature(isAffirmative(featuresData.elevador), 'assets/images/iconcaracteristic/icon_elevator.png', 'Elevador', 'Elevador');
+            addFeature(isAffirmative(featuresData?.amenidades?.gimnasio), 'assets/images/iconcaracteristic/icon_gym.png', 'Gimnasio', 'Gimnasio');
+            addFeature(isAffirmative(featuresData?.amenidades?.alberca), 'assets/images/iconcaracteristic/icon_pool.png', 'Alberca', 'Alberca');
+            addFeature(isAffirmative(featuresData?.amenidades?.salon_eventos), 'assets/images/iconcaracteristic/icon_event_hall.png', 'Salón de eventos', 'Salón de Eventos');
+        } else if (normalizedCategory === 'terrenos') {
+            addFeature(hasValue(featuresData.superficie_total), 'assets/images/iconcaracteristic/icon_total_area.png', 'Superficie', `${featuresData.superficie_total}`);
+            addFeature(hasValue(featuresData.frente), 'assets/images/iconcaracteristic/icon_dimensions.png', 'Frente', `${featuresData.frente}m de Frente`);
+            addFeature(hasValue(featuresData.fondo), 'assets/images/iconcaracteristic/icon_dimensions.png', 'Fondo', `${featuresData.fondo}m de Fondo`);
+            addFeature(hasValue(featuresData.tipo_suelo), 'assets/images/iconcaracteristic/icon_soil.png', 'Tipo de suelo', `Suelo: ${featuresData.tipo_suelo}`);
+            addFeature(hasValue(featuresData.tipo_propiedad), 'assets/images/iconcaracteristic/icon_property_type.png', 'Tipo de propiedad', `Propiedad ${capitalizeFirst(String(featuresData.tipo_propiedad))}`);
+            addFeature(isAffirmative(featuresData?.servicios?.luz), 'assets/images/iconcaracteristic/icon_electricity.png', 'Servicio de luz', 'Servicio de Luz');
+            addFeature(isAffirmative(featuresData?.servicios?.agua), 'assets/images/iconcaracteristic/icon_water.png', 'Servicio de agua', 'Servicio de Agua');
+            addFeature(isAffirmative(featuresData?.servicios?.drenaje), 'assets/images/iconcaracteristic/icon_drainage.png', 'Drenaje', 'Drenaje');
+        } else if (normalizedCategory === 'desarrollos') {
+            addFeature(hasValue(featuresData.num_unidades), 'assets/images/iconcaracteristic/icon_units.png', 'Unidades', `${featuresData.num_unidades} Unidades`);
+            addFeature(hasValue(featuresData.superficie_min), 'assets/images/iconcaracteristic/icon_total_area.png', 'Superficie mínima', `Desde ${featuresData.superficie_min} m²`);
+            addFeature(hasValue(featuresData.superficie_max), 'assets/images/iconcaracteristic/icon_total_area.png', 'Superficie máxima', `Hasta ${featuresData.superficie_max} m²`);
+            addFeature(hasValue(featuresData.rango_recamaras), 'assets/images/iconcaracteristic/icon_bed.png', 'Recámaras', `${featuresData.rango_recamaras} Recámaras`);
+            addFeature(hasValue(featuresData.rango_banos), 'assets/images/iconcaracteristic/icon_bath.png', 'Baños', `${featuresData.rango_banos} Baños`);
+            if (hasValue(featuresData.etapas)) {
+                const etapa = String(featuresData.etapas).replace(/_/g, ' ');
+                addFeature(true, 'assets/images/iconcaracteristic/icon_timeline.png', 'Etapa', `Etapa: ${capitalizeFirst(etapa)}`);
+            }
+            addFeature(hasValue(featuresData.entrega_estimada), 'assets/images/iconcaracteristic/icon_calendar.png', 'Entrega estimada', `Entrega: ${featuresData.entrega_estimada}`);
+            addFeature(isAffirmative(featuresData.pet_friendly), 'assets/images/iconcaracteristic/icon_pet_friendly.png', 'Pet friendly', 'Pet Friendly');
+            addFeature(isAffirmative(featuresData?.amenidades?.alberca), 'assets/images/iconcaracteristic/icon_pool.png', 'Alberca', 'Alberca');
+            addFeature(isAffirmative(featuresData?.amenidades?.areas_verdes), 'assets/images/iconcaracteristic/icon_green_areas.png', 'Áreas verdes', 'Áreas Verdes');
+            addFeature(isAffirmative(featuresData?.amenidades?.gimnasio), 'assets/images/iconcaracteristic/icon_gym.png', 'Gimnasio', 'Gimnasio');
+        }
+
+        if (featureItems.length === 0) {
+            sectionEl.hidden = true;
+            return;
+        }
+
+        sectionEl.hidden = false;
+        featureItems.forEach((item) => {
+            const listItem = document.createElement('li');
+            listItem.className = 'property-info__feature-item';
+
+            const icon = document.createElement('img');
+            icon.src = item.icon;
+            icon.alt = item.alt;
+            listItem.appendChild(icon);
+
+            const text = document.createElement('span');
+            text.textContent = item.label;
+            listItem.appendChild(text);
+
+            listEl.appendChild(listItem);
+        });
+    }
+
+    function sanitizeString(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value).trim();
+    }
+
+    function capitalizeFirst(value) {
+        if (!value) {
+            return '';
+        }
+        return value.charAt(0).toUpperCase() + value.slice(1);
+    }
+
+    function formatMultiline(text) {
+        return escapeHtml(text).replace(/\r?\n/g, '<br>');
+    }
+
+    function escapeHtml(text) {
+        if (typeof text !== 'string') {
+            return '';
+        }
+        return text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function showError(message, contentContainer, errorContainer, errorMessageEl, similarSection) {
+        if (contentContainer) {
+            contentContainer.hidden = true;
+        }
+        if (similarSection) {
+            similarSection.hidden = true;
+        }
+        if (errorContainer) {
+            errorContainer.hidden = false;
+        }
+        if (errorMessageEl) {
+            errorMessageEl.textContent = message;
+        }
+        document.title = 'Propiedad no encontrada - DOMABLY';
+    }
+
+    function updateFooterYear(footerYearEl) {
+        if (footerYearEl) {
+            footerYearEl.textContent = String(new Date().getFullYear());
+        }
+    }
+})();

--- a/frontend/property_detail.html
+++ b/frontend/property_detail.html
@@ -1,42 +1,9 @@
-<?php
-include 'includes/config.php';
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$stmt = $pdo->prepare("SELECT * FROM properties WHERE id = :id AND status = 'disponible'");
-$stmt->bindParam(':id', $id);
-$stmt->execute();
-$property = $stmt->fetch(PDO::FETCH_ASSOC);
-
-if (!$property) {
-    header("Location: properties.html");
-    exit;
-}
-
-// Recolectar todas las imágenes disponibles en un array limpio
-$images = [];
-if ($property['main_image']) {
-    $images[] = $property['main_image'];
-}
-for ($i = 1; $i <= 15; $i++) {
-    if (!empty($property["thumbnail$i"])) {
-        $images[] = $property["thumbnail$i"];
-    }
-}
-$main_gallery_images = array_slice($images, 0, 5);
-$total_images = count($images);
-
-// --- Lógica para Propiedades Similares ---
-$similar_stmt = $pdo->prepare("SELECT * FROM properties WHERE category = :category AND id != :id AND status = 'disponible' ORDER BY RAND() LIMIT 10");
-$similar_stmt->execute(['category' => $property['category'], 'id' => $id]);
-$similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
-
-?>
-
 <!DOCTYPE html>
 <html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo htmlspecialchars($property['title']); ?> - DOMABLY</title>
+    <title>Detalle de Propiedad - DOMABLY</title>
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body class="property-detail-page">
@@ -52,7 +19,7 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
             </div>
             <!-- Logo -->
             <div class="header__logo">
-                <a href="index.php">
+                <a href="index.html">
                     <img src="assets/images/iconcaracteristic/logo-light.png" alt="Logo DOMABLY" class="header__logo--light">
                     <img src="assets/images/iconcaracteristic/logo-dark.png" alt="Logo DOMABLY" class="header__logo--dark">
                     <h1 class="header__title sr-only">DOMABLY</h1>
@@ -80,7 +47,7 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
                         <span class="mobile-nav__close-button">✕</span>
                     </li>
 
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="index.php"><img src="assets/images/iconcaracteristic/home-icon.png" alt="Inicio Icon" class="mobile-nav__icon">Inicio</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="index.html"><img src="assets/images/iconcaracteristic/home-icon.png" alt="Inicio Icon" class="mobile-nav__icon">Inicio</a></li>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="properties.html"><img src="assets/images/iconcaracteristic/properties-icon.png" alt="Propiedades Icon" class="mobile-nav__icon">Propiedades</a></li>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="contact.php"><img src="assets/images/iconcaracteristic/contact-icon.png" alt="Contacto Icon" class="mobile-nav__icon">Contacto</a></li>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="about.php"><img src="assets/images/iconcaracteristic/about-icon.png" alt="Sobre Nosotros Icon" class="mobile-nav__icon">Sobre Nosotros</a></li>
@@ -93,45 +60,29 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
 </header>
 
     <main class="property-detail">
-        <div class="container">
+        <div class="container" id="property-content">
             <div class="property-detail__header">
                 <a href="javascript:history.back()" class="property-detail__back-link">← Volver a la búsqueda</a>
             </div>
 
-            <?php if (!empty($main_gallery_images)): ?>
-            <section class="gallery">
-                <div class="gallery__layout">
-                    <?php foreach($main_gallery_images as $index => $image_src): ?>
-                        <div class="gallery__item <?php if($index == 0) echo 'gallery__item--large'; else echo 'gallery__item--thumb'; ?>" data-index="<?php echo $index; ?>">
-                            <img src="<?php echo htmlspecialchars($image_src); ?>" alt="Vista <?php echo $index + 1; ?> de <?php echo htmlspecialchars($property['title']); ?>" class="gallery__image">
-                            <?php if ($index === count($main_gallery_images) - 1 && $total_images > count($main_gallery_images)): ?>
-                                <div class="gallery__overlay">
-                                <div class="gallery__photo-count">
-                                    <?php // --- INICIO DEL CAMBIO --- ?>
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-camera"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
-                                    <span><?php echo $total_images; ?> Fotos</span>
-                                </div>
-                                </div>
-                            <?php endif; ?>  
-                        </div>
-                    <?php endforeach; ?>
-                </div>
+            <section class="gallery" id="gallery-section" hidden>
+                <div class="gallery__layout" id="gallery-layout"></div>
                 <nav class="breadcrumb" aria-label="breadcrumb">
                     <ol class="breadcrumb__list">
                         <li class="breadcrumb__item">
-                            <a href="index.php" class="breadcrumb__link">Domably</a>
+                            <a href="index.html" class="breadcrumb__link">Domably</a>
                         </li>
                         <li class="breadcrumb__separator" aria-hidden="true">></li>
                         <li class="breadcrumb__item">
-                            <a href="properties.html?listing_type=<?php echo urlencode($property['listing_type']); ?>" class="breadcrumb__link"><?php echo htmlspecialchars(ucfirst($property['listing_type'])); ?></a>
+                            <a href="properties.html" class="breadcrumb__link" id="breadcrumb-listing">Propiedades</a>
                         </li>
                         <li class="breadcrumb__separator" aria-hidden="true">></li>
                         <li class="breadcrumb__item">
-                            <a href="properties.html?location=<?php echo urlencode($property['location']); ?>" class="breadcrumb__link"><?php echo htmlspecialchars($property['location']); ?></a>
+                            <a href="properties.html" class="breadcrumb__link" id="breadcrumb-location">Ubicación</a>
                         </li>
                         <li class="breadcrumb__separator" aria-hidden="true">></li>
                         <li class="breadcrumb__item">
-                            <a href="properties.html?category=<?php echo urlencode($property['category']); ?>" class="breadcrumb__link"><?php echo htmlspecialchars(ucfirst($property['category'])); ?></a>
+                            <a href="properties.html" class="breadcrumb__link" id="breadcrumb-category">Categoría</a>
                         </li>
                     </ol>
                 </nav>
@@ -146,87 +97,25 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
                     </button>
                 </div>
             </section>
-            <?php endif; ?>
-
-
 
             <div class="property-detail__main-content">
                 <article class="property-detail__info-wrapper">
                     <div class="property-info">
                         <div class="property-info__header">
-                            <h1 class="property-info__title"><?php echo htmlspecialchars($property['title']); ?></h1>
+                            <h1 class="property-info__title" id="property-title"></h1>
                             <p class="property-info__location">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8 16s6-5.686 6-10A6 6 0 0 0 2 6c0 4.314 6 10 6 10zm0-7a3 3 0 1 1 0-6 3 3 0 0 1 0 6z"/></svg>
-                                <?php echo htmlspecialchars($property['location']); ?>
+                                <span id="property-location"></span>
                             </p>
                         </div>
-                        <p class="property-info__price">
-                            $<?php echo number_format($property['price'], 2); ?> MXN
-                            <?php if ($property['listing_type'] == 'renta'): ?>
-                                <span class="property-info__price-period">/ Mes</span>
-                            <?php endif; ?>
-                        </p>
+                        <p class="property-info__price" id="property-price"></p>
                         <div class="property-info__description">
                             <h3>Descripción</h3>
-                            <p><?php echo nl2br(htmlspecialchars($property['description'])); ?></p>
+                            <p id="property-description"></p>
                         </div>
-                        <div class="property-info__features">
+                        <div class="property-info__features" id="property-features-section">
                             <h3>Características</h3>
-                            <ul class="property-info__features-list">
-                                <?php
-                                $features = json_decode($property['features'], true) ?: [];
-
-                                // --- Lógica para CASAS ---
-                                if ($property['category'] === 'casas') {
-                                    if (!empty($features['recamaras'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_bed.png" alt="Recámaras"><span>' . htmlspecialchars($features['recamaras']) . ' Recámaras</span></li>';
-                                    if (!empty($features['banos'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_bath.png" alt="Baños"><span>' . htmlspecialchars($features['banos']) . ' Baños</span></li>';
-                                    if (!empty($features['estacionamientos'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_parking.png" alt="Estacionamientos"><span>' . htmlspecialchars($features['estacionamientos']) . ' Estacionamientos</span></li>';
-                                    if (!empty($features['superficie_construida'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_built_area.png" alt="Construcción"><span>' . htmlspecialchars($features['superficie_construida']) . ' m² Construidos</span></li>';
-                                    if (!empty($features['superficie_total'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_total_area.png" alt="Terreno"><span>' . htmlspecialchars($features['superficie_total']) . ' m² Terreno</span></li>';
-                                    if (!empty($features['niveles'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_floors.png" alt="Niveles"><span>' . htmlspecialchars($features['niveles']) . ' Niveles</span></li>';
-                                    if (!empty($features['terraza']) && $features['terraza'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_terrace.png" alt="Terraza"><span>Terraza</span></li>';
-                                    if (!empty($features['alberca']) && $features['alberca'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_pool.png" alt="Alberca"><span>Alberca</span></li>';
-                                    if (!empty($features['amueblada']) && $features['amueblada'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_furniture.png" alt="Amueblada"><span>Amueblada</span></li>';
-                                }
-                                // --- Lógica para DEPARTAMENTOS ---
-                                elseif ($property['category'] === 'departamentos') {
-                                    if (!empty($features['recamaras'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_bed.png" alt="Recámaras"><span>' . htmlspecialchars($features['recamaras']) . ' Recámaras</span></li>';
-                                    if (!empty($features['banos'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_bath.png" alt="Baños"><span>' . htmlspecialchars($features['banos']) . ' Baños</span></li>';
-                                    if (!empty($features['estacionamientos'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_parking.png" alt="Estacionamientos"><span>' . htmlspecialchars($features['estacionamientos']) . ' Estacionamientos</span></li>';
-                                    if (!empty($features['superficie_total'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_built_area.png" alt="Construcción"><span>' . htmlspecialchars($features['superficie_total']) . ' m² Totales</span></li>';
-                                    if (!empty($features['piso'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_floors.png" alt="Piso"><span>Piso ' . htmlspecialchars($features['piso']) . '</span></li>';
-                                    if (!empty($features['elevador']) && $features['elevador'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_elevator.png" alt="Elevador"><span>Elevador</span></li>';
-                                    if (!empty($features['amenidades']['gimnasio']) && $features['amenidades']['gimnasio'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_gym.png" alt="Gimnasio"><span>Gimnasio</span></li>';
-                                    if (!empty($features['amenidades']['alberca']) && $features['amenidades']['alberca'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_pool.png" alt="Alberca"><span>Alberca</span></li>';
-                                    if (!empty($features['amenidades']['salon_eventos']) && $features['amenidades']['salon_eventos'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_event_hall.png" alt="Salón de Eventos"><span>Salón de Eventos</span></li>';
-                                }
-                                // --- Lógica para TERRENOS ---
-                                elseif ($property['category'] === 'terrenos') {
-                                    if (!empty($features['superficie_total'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_total_area.png" alt="Superficie"><span>' . htmlspecialchars($features['superficie_total']) . '</span></li>';
-                                    if (!empty($features['frente'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_dimensions.png" alt="Frente"><span>' . htmlspecialchars($features['frente']) . 'm de Frente</span></li>';
-                                    if (!empty($features['fondo'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_dimensions.png" alt="Fondo"><span>' . htmlspecialchars($features['fondo']) . 'm de Fondo</span></li>';
-                                    if (!empty($features['tipo_suelo'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_soil.png" alt="Tipo de Suelo"><span>Suelo: ' . htmlspecialchars($features['tipo_suelo']) . '</span></li>';
-                                    if (!empty($features['tipo_propiedad'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_property_type.png" alt="Tipo de Propiedad"><span>Propiedad ' . ucfirst(htmlspecialchars($features['tipo_propiedad'])) . '</span></li>';
-                                    if (!empty($features['servicios']['luz']) && $features['servicios']['luz'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_electricity.png" alt="Luz"><span>Servicio de Luz</span></li>';
-                                    if (!empty($features['servicios']['agua']) && $features['servicios']['agua'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_water.png" alt="Agua"><span>Servicio de Agua</span></li>';
-                                    if (!empty($features['servicios']['drenaje']) && $features['servicios']['drenaje'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_drainage.png" alt="Drenaje"><span>Drenaje</span></li>';
-                                }
-                                // --- Lógica para DESARROLLOS ---
-                                elseif ($property['category'] === 'desarrollos') {
-                                    if (!empty($features['num_unidades'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_units.png" alt="Unidades"><span>' . htmlspecialchars($features['num_unidades']) . ' Unidades</span></li>';
-                                    if (!empty($features['superficie_min'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_total_area.png" alt="Superficie Mínima"><span>Desde ' . htmlspecialchars($features['superficie_min']) . ' m²</span></li>';
-                                    if (!empty($features['superficie_max'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_total_area.png" alt="Superficie Máxima"><span>Hasta ' . htmlspecialchars($features['superficie_max']) . ' m²</span></li>';
-                                    if (!empty($features['rango_recamaras'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_bed.png" alt="Recámaras"><span>' . htmlspecialchars($features['rango_recamaras']) . ' Recámaras</span></li>';
-                                    if (!empty($features['rango_banos'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_bath.png" alt="Baños"><span>' . htmlspecialchars($features['rango_banos']) . ' Baños</span></li>';
-                                    if (!empty($features['etapas'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_timeline.png" alt="Etapa"><span>Etapa: ' . ucfirst(str_replace('_', ' ', htmlspecialchars($features['etapas']))) . '</span></li>';
-                                    if (!empty($features['entrega_estimada'])) echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_calendar.png" alt="Entrega"><span>Entrega: ' . htmlspecialchars($features['entrega_estimada']) . '</span></li>';
-                                    if (!empty($features['pet_friendly']) && $features['pet_friendly'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_pet_friendly.png" alt="Pet Friendly"><span>Pet Friendly</span></li>';
-                                    if (!empty($features['amenidades']['alberca']) && $features['amenidades']['alberca'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_pool.png" alt="Alberca"><span>Alberca</span></li>';
-                                    if (!empty($features['amenidades']['areas_verdes']) && $features['amenidades']['areas_verdes'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_green_areas.png" alt="Áreas Verdes"><span>Áreas Verdes</span></li>';
-                                    if (!empty($features['amenidades']['gimnasio']) && $features['amenidades']['gimnasio'] === 'Sí') echo '<li class="property-info__feature-item"><img src="assets/images/iconcaracteristic/icon_gym.png" alt="Gimnasio"><span>Gimnasio</span></li>';
-                                }
-                                ?>
-                            </ul>
+                            <ul class="property-info__features-list" id="property-features"></ul>
                         </div>
                         <div class="next-steps">
                             <h3 class="next-steps__main-title">¿Interesado? Sigue estos pasos</h3>
@@ -272,12 +161,12 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
                         <div class="advertiser-info">
                             <h3 class="advertiser-info__main-title">Información del anunciante</h3>
                             <div class="advertiser-info__content">
-                                <a href="index.php" class="advertiser-info__header">
+                                <a href="index.html" class="advertiser-info__header">
                                     <img src="assets/images/iconcaracteristic/icono_doma.png" alt="Logo Domably" class="advertiser-info__logo">
                                     <span class="advertiser-info__name">Domably Inmobiliaria</span>
                                 </a>
                                 <div class="advertiser-info__details">
-                                    <p class="advertiser-info__code">Código de propiedad: <?php echo htmlspecialchars($property['id']); ?></p>
+                                    <p class="advertiser-info__code">Código de propiedad: <span id="property-code"></span></p>
                                 </div>
                             </div>
                         </div>
@@ -293,17 +182,18 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
                                 <button type="button" class="report-listing__button">No me puedo contactar</button>
                                 <button type="button" class="report-listing__button">Otros motivos</button>
                             </div>
+                        </div>
                     </div>
                 </article>
-                
+
                 <aside class="property-detail__contact-wrapper">
                     <div class="contact-card">
                         <div class="contact-card__form-section">
                             <h3 class="contact-card__title">Contacta al anunciante</h3>
                             <form action="contact.php" method="POST" class="contact-card__form">
-                                <input type="hidden" name="property_id" value="<?php echo $property['id']; ?>">
-                                <input type="hidden" name="property_title" value="<?php echo htmlspecialchars($property['title']); ?>">
-                                            
+                                <input type="hidden" name="property_id" id="contact-property-id">
+                                <input type="hidden" name="property_title" id="contact-property-title">
+
                                 <div class="contact-card__form-group">
                                     <label for="contact-name" class="sr-only">Nombre</label>
                                     <input type="text" id="contact-name" name="name" placeholder="Nombre" required class="contact-card__input">
@@ -318,22 +208,22 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
                                 </div>
                                 <div class="contact-card__form-group">
                                     <label for="contact-message" class="sr-only">Mensaje</label>
-                                    <textarea id="contact-message" name="message" rows="4" required class="contact-card__textarea"><?php echo "¡Hola! Quiero que se comuniquen conmigo por este inmueble: " . htmlspecialchars($property['title']) . ". Gracias."; ?></textarea>
+                                    <textarea id="contact-message" name="message" rows="4" required class="contact-card__textarea"></textarea>
                                 </div>
-                                            
+
                                 <button type="submit" class="btn btn-primary contact-card__button">
                                     Contactar
                                     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
                                 </button>
                             </form>
-                                            
-                            <a href="https://wa.me/5219997632818?text=Estoy%20interesado%20en%20la%20propiedad:%20<?php echo urlencode($property['title']); ?>" class="btn btn-whatsapp contact-card__button" target="_blank">
+
+                            <a href="#" class="btn btn-whatsapp contact-card__button" target="_blank" id="contact-whatsapp">
                                 Contactar por WhatsApp
                                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M16.75 13.96c.25.13.43.2.5.25.13.06.16.19.16.38 0 .13-.03.25-.09.38-.19.31-.44.56-.75.75-.31.19-.69.28-1.13.28-.25 0-.5-.06-.75-.19-.5-.25-.94-.59-1.31-1.03-.44-.44-.81-.94-1.13-1.5-.31-.56-.47-1.16-.47-1.78 0-.25.03-.5.09-.75.06-.25.16-.47.28-.66.13-.19.28-.31.47-.38.19-.06.31-.09.38-.09.25 0 .47.03.66.09.19.06.31.19.38.31s.09.31.09.53c0 .06-.01.16-.03.25-.01.1-.03.19-.06.28-.03.09-.06.16-.09.22a.86.86 0 00-.19.28c-.06.13-.09.22-.09.28 0 .13.03.22.09.28.16.19.38.35.66.5.28.16.5.28.75.38.25.09.44.13.56.13.13 0 .25-.01.38-.03a.88.88 0 00.28-.16c.09-.06.16-.09.22-.09.16-.06.28-.09.31-.09.25-.03.5-.03.75.03.25.06.44.13.56.19zM12 2a10 10 0 1010 10A10 10 0 0012 2zm0 18.13a8.13 8.13 0 118.13-8.13A8.14 8.14 0 0112 20.13z"></path></svg>
                             </a>
                             <p class="contact-card__legal">Al enviar estás aceptando los Términos y condiciones de Uso y la Política de Privacidad.</p>
                         </div>
-                                            
+
                         <div class="contact-card__agent-section">
                             <img src="assets/images/iconcaracteristic/icono_doma.png" alt="Logo Domably" class="contact-card__agent-logo">
                             <div class="contact-card__agent-details">
@@ -351,50 +241,32 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
                 </aside>
             </div>
 
-            <?php if ($property['latitude'] && $property['longitude']): ?>
-            <section class="property-detail__map">
+            <section class="property-detail__map" id="property-map-section" hidden>
                 <h3>Ubicación</h3>
-                <iframe src="https://maps.google.com/maps?q=<?php echo urlencode($property['latitude'] . ',' . $property['longitude']); ?>&t=&z=15&ie=UTF8&iwloc=&output=embed" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+                <iframe id="property-map-frame" src="" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
             </section>
-            <?php endif; ?>
-        </div>
-            <?php if (!empty($similar_properties)): ?>
-            <section class="recommendations">
-                <div class="container">
-                    <div class="recommendations__header">
-                        <h2 class="recommendations__title">Propiedades Similares</h2>
-                        <div class="recommendations__nav">
-                            <button class="recommendations__arrow" id="similar-prev">&lt;</button>
-                            <button class="recommendations__arrow" id="similar-next">&gt;</button>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="recommendations__grid-wrapper" id="similar-carousel-wrapper">
-                    <div class="recommendations__grid">
-                        <?php foreach ($similar_properties as $similar_property): ?>
-                            <div class="property-card">
-                                <a href="property_detail.php?id=<?php echo $similar_property['id']; ?>" class="property-card__link">
-                                    <div class="property-card__image-container">
-                                        <img class="property-card__image" src="<?php echo htmlspecialchars($similar_property['main_image']); ?>" alt="<?php echo htmlspecialchars($similar_property['title']); ?>">
-                                        <div class="property-card__badge property-card__badge--listing"><?php echo htmlspecialchars(ucfirst($similar_property['listing_type'])); ?></div>
-                                        <div class="property-card__badge property-card__badge--category"><?php echo htmlspecialchars(ucfirst($similar_property['category'])); ?></div>
-                                    </div>
-                                    <div class="property-card__content">
-                                        <h3 class="property-card__title"><?php echo htmlspecialchars($similar_property['title']); ?></h3>
-                                    </div>
-                                    <div class="property-card__footer">
-                                        <p class="property-card__price">$<?php echo number_format($similar_property['price'], 2); ?> MXN</p>
-                                    </div>
-                                </a>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
-                </div>
-            </section>
-            <?php endif; ?>
         </div>
     </main>
+
+    <section class="recommendations" id="similar-section" hidden>
+        <div class="container">
+            <div class="recommendations__header">
+                <h2 class="recommendations__title">Propiedades Similares</h2>
+                <div class="recommendations__nav">
+                    <button class="recommendations__arrow" id="similar-prev">&lt;</button>
+                    <button class="recommendations__arrow" id="similar-next">&gt;</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="recommendations__grid-wrapper" id="similar-carousel-wrapper">
+            <div class="recommendations__grid" id="similar-grid"></div>
+        </div>
+    </section>
+
+    <div class="container property-detail__error" id="property-error" hidden>
+        <p id="property-error-message">Estamos cargando la información de la propiedad.</p>
+    </div>
 
     <div class="lightbox" id="property-lightbox">
         <div class="lightbox__overlay"></div>
@@ -405,8 +277,7 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
                     <h3>Todas las fotos</h3>
                     <button class="lightbox__close" aria-label="Cerrar">×</button>
                 </div>
-                <div class="lightbox__grid-container" id="lightbox-grid-container">
-                    </div>
+                <div class="lightbox__grid-container" id="lightbox-grid-container"></div>
             </div>
 
             <div class="lightbox__slider-view" id="lightbox-slider-view">
@@ -418,7 +289,7 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
                     <img src="" alt="Vista ampliada de la propiedad" id="lightbox-main-image">
                 </div>
                 <span class="lightbox__counter" id="lightbox-counter"></span>
-                                
+
                 <button class="lightbox__nav lightbox__nav--prev" aria-label="Anterior">❮</button>
                 <button class="lightbox__nav lightbox__nav--next" aria-label="Siguiente">❯</button>
             </div>
@@ -462,13 +333,12 @@ $similar_properties = $similar_stmt->fetchAll(PDO::FETCH_ASSOC);
         </div>
     </div>
     <div class="site-footer__bottom">
-        <p>&copy; <?php echo date("Y"); ?> DOMABLY. Todos los derechos reservados.</p>
+        <p>&copy; <span id="footer-year"></span> DOMABLY. Todos los derechos reservados.</p>
     </div>
 </footer>
 
-    <script>
-        const propertyImages = <?php echo json_encode($images); ?>;
-    </script>
+    <script>window.propertyImages = [];</script>
     <script src="assets/js/main.js"></script>
+    <script src="assets/js/property-detail.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an API route to serve property details, images, and similar listings
- replace the PHP property detail view with an HTML page that loads data from the backend via JavaScript
- introduce a dedicated property detail script, update the lightbox initialization, and point existing links to the new page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb0c3b88e883208911b43d20169998