### PR TITLE
Add authentication controls to home header

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -19,6 +19,10 @@ body {
     margin: 0;
 }
 
+body.no-scroll {
+    overflow: hidden;
+}
+
 .container {
     max-width: 1500px; /* <-- Aumentamos el valor de 1200px a 1500px */
     margin: 0 auto;
@@ -156,7 +160,8 @@ body:not(.home){
     vertical-align: middle;
 }
 
-.mobile-nav__list li a {
+.mobile-nav__list li a,
+.mobile-nav__button {
     display: flex;
     align-items: center;
     width: 100%;
@@ -168,10 +173,215 @@ body:not(.home){
     transition: color 0.3s ease, background 0.3s ease;
 }
 
-.mobile-nav__list li a:hover {
+.mobile-nav__button {
+    background: transparent;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+}
+
+.mobile-nav__list li a:hover,
+.mobile-nav__button:hover {
     color: #3498db;
     background: #f1f1f1;
     border-radius: 5px;
+}
+
+.mobile-nav__button--primary {
+    background: #0f96da;
+    color: #fff;
+    border-radius: 8px;
+    margin: 0 10px;
+    padding: 12px 16px;
+    font-weight: 600;
+}
+
+.mobile-nav__button--primary:hover {
+    background: #0d7fb7;
+    color: #fff;
+}
+
+.mobile-nav__button--primary .mobile-nav__icon {
+    filter: brightness(0) invert(1);
+}
+
+.mobile-nav__link--account {
+    font-weight: 600;
+    color: #0f96da;
+}
+
+.mobile-nav__link--account:hover {
+    color: #0d7fb7;
+}
+
+/* ================================================= */
+/* === MODALES DE AUTENTICACIÓN === */
+/* ================================================= */
+.auth-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    z-index: 2000;
+}
+
+.auth-modal.is-open {
+    opacity: 1;
+    visibility: visible;
+}
+
+.auth-modal__content {
+    width: min(440px, 100%);
+    background: #fff;
+    border-radius: 24px;
+    padding: 34px 36px 32px;
+    position: relative;
+    box-shadow: 0 25px 60px rgba(15, 150, 218, 0.18);
+    animation: fadeIn 0.35s ease-out;
+}
+
+.auth-modal__close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    background: transparent;
+    border: none;
+    font-size: 20px;
+    color: #95a5a6;
+    cursor: pointer;
+    transition: color 0.3s ease, transform 0.3s ease;
+}
+
+.auth-modal__close:hover {
+    color: #0f96da;
+    transform: scale(1.05);
+}
+
+.auth-modal__title {
+    font-size: 26px;
+    font-weight: 700;
+    color: #2c3e50;
+    margin-bottom: 6px;
+}
+
+.auth-modal__description {
+    font-size: 15px;
+    color: #5d6d7e;
+    margin-bottom: 24px;
+}
+
+.auth-modal__form {
+    display: flex;
+    flex-direction: column;
+}
+
+.auth-modal__form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 16px;
+}
+
+.auth-modal__form-group label {
+    font-size: 14px;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.auth-modal__form-group input {
+    border: 1px solid rgba(44, 62, 80, 0.25);
+    border-radius: 12px;
+    padding: 12px 14px;
+    font-size: 14px;
+    color: #2c3e50;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.auth-modal__form-group input:focus {
+    outline: none;
+    border-color: #0f96da;
+    box-shadow: 0 0 0 3px rgba(15, 150, 218, 0.15);
+}
+
+.auth-modal__submit {
+    width: 100%;
+    justify-content: center;
+    margin-top: 4px;
+}
+
+.auth-modal__message {
+    min-height: 20px;
+    margin-top: 12px;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.auth-modal__message--error {
+    color: #c0392b;
+}
+
+.auth-modal__message--success {
+    color: #27ae60;
+}
+
+.auth-modal__footer {
+    margin-top: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 14px;
+    color: #5d6d7e;
+}
+
+.auth-modal__link {
+    border: none;
+    background: none;
+    color: #0f96da;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+}
+
+.auth-modal__link:hover {
+    text-decoration: underline;
+}
+
+.auth-modal__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(10, 25, 47, 0.55);
+    z-index: 1900;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.auth-modal__overlay.is-active {
+    opacity: 1;
+}
+
+.auth-modal__overlay[hidden] {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    .auth-modal__content {
+        padding: 28px 22px 24px;
+        border-radius: 20px;
+    }
+
+    .auth-modal__title {
+        font-size: 24px;
+    }
+
+    .auth-modal__submit {
+        font-size: 15px;
+    }
 }
 
 /* Ajustar el botón de cerrar para no interferir con los íconos */
@@ -209,6 +419,91 @@ body:not(.home){
     cursor: pointer;
     color: #fff; /* Blanco inicialmente en index */
     transition: color 0.3s ease; /* Transición suave para el color */
+}
+
+.header__actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.header__action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px 20px;
+    border-radius: 999px;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    background: transparent;
+    color: #fff;
+    transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.header__action-btn--primary {
+    background: #0f96da;
+    border-color: #0f96da;
+    color: #fff;
+    box-shadow: 0 10px 25px rgba(15, 150, 218, 0.25);
+}
+
+.header__action-btn--primary:hover {
+    background: #0d7fb7;
+    border-color: #0d7fb7;
+    box-shadow: 0 12px 30px rgba(15, 150, 218, 0.35);
+}
+
+.header__action-btn--ghost {
+    color: #fff;
+}
+
+.header__action-btn--ghost:hover {
+    background: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.8);
+}
+
+.header__action-btn--account {
+    min-width: 130px;
+}
+
+.header__action-btn:focus-visible {
+    outline: 2px solid #0f96da;
+    outline-offset: 2px;
+}
+
+.header--scrolled .header__action-btn,
+body:not(.home) .header__action-btn {
+    border-color: rgba(44, 62, 80, 0.35);
+    color: #2c3e50;
+    box-shadow: none;
+}
+
+.header--scrolled .header__action-btn--ghost,
+body:not(.home) .header__action-btn--ghost {
+    background: transparent;
+}
+
+.header--scrolled .header__action-btn--ghost:hover,
+body:not(.home) .header__action-btn--ghost:hover {
+    background: rgba(15, 150, 218, 0.12);
+    border-color: rgba(15, 150, 218, 0.4);
+    color: #0f96da;
+}
+
+.header--scrolled .header__action-btn--primary,
+body:not(.home) .header__action-btn--primary {
+    border-color: #0f96da;
+    color: #fff;
+}
+
+.header--scrolled .header__action-btn--primary:hover,
+body:not(.home) .header__action-btn--primary:hover {
+    background: #0d7fb7;
 }
 
 
@@ -716,6 +1011,10 @@ body:not(.home) .header__nav-item a {
         justify-content: space-between; /* Espacia los elementos */
         padding: 8px 20px; /* Padding uniforme para móviles */
         position: relative;
+    }
+
+    .header__actions {
+        display: none;
     }
 
     body:not(.home){

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,17 @@
                         <h1 class="header__title sr-only">DOMABLY</h1>
                     </a>
                 </div>
+                <div class="header__actions">
+                    <button type="button" class="header__action-btn header__action-btn--ghost" data-auth-trigger="login" data-auth-visible="guest">
+                        Iniciar sesión
+                    </button>
+                    <button type="button" class="header__action-btn header__action-btn--primary" data-auth-trigger="register" data-auth-visible="guest">
+                        Crear cuenta
+                    </button>
+                    <a class="header__action-btn header__action-btn--primary header__action-btn--account" href="properties.html" data-account-link data-account-href-admin="admin/dashboard.php" data-account-href-user="properties.html" data-auth-visible="authenticated" hidden>
+                        Mi cuenta
+                    </a>
+                </div>
             </div>
             <hr class="header__divider">
             <ul class="header__nav">
@@ -46,7 +57,21 @@
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="contact.php"><img src="assets/images/iconcaracteristic/contact-icon.png" alt="Contacto Icon" class="mobile-nav__icon">Contacto</a></li>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="about.php"><img src="assets/images/iconcaracteristic/about-icon.png" alt="Sobre Nosotros Icon" class="mobile-nav__icon">Sobre Nosotros</a></li>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="join.php"><img src="assets/images/iconcaracteristic/join-icon.png" alt="Únete a Nosotros Icon" class="mobile-nav__icon">Únete a Nosotros</a></li>
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="admin/index.php"><img src="assets/images/iconcaracteristic/account-icon.png" alt="Mi Cuenta Icon" class="mobile-nav__icon">Mi Cuenta</a></li>
+                    <li class="mobile-nav__item" data-auth-visible="guest">
+                        <button type="button" class="mobile-nav__link mobile-nav__button" data-auth-trigger="login">
+                            <img src="assets/images/iconcaracteristic/account-icon.png" alt="Icono iniciar sesión" class="mobile-nav__icon">Iniciar sesión
+                        </button>
+                    </li>
+                    <li class="mobile-nav__item" data-auth-visible="guest">
+                        <button type="button" class="mobile-nav__link mobile-nav__button mobile-nav__button--primary" data-auth-trigger="register">
+                            <img src="assets/images/iconcaracteristic/join-icon.png" alt="Icono crear cuenta" class="mobile-nav__icon">Crear cuenta
+                        </button>
+                    </li>
+                    <li class="mobile-nav__item" data-auth-visible="authenticated" hidden>
+                        <a class="mobile-nav__link mobile-nav__link--account" href="properties.html" data-account-link data-account-href-admin="admin/dashboard.php" data-account-href-user="properties.html">
+                            <img src="assets/images/iconcaracteristic/account-icon.png" alt="Mi Cuenta Icon" class="mobile-nav__icon">Mi Cuenta
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>
@@ -209,7 +234,73 @@
         </div>
     </footer>
 
+    <div class="auth-modal__overlay" id="auth-modal-overlay" hidden></div>
+
+    <section class="auth-modal" id="login-modal" role="dialog" aria-modal="true" aria-labelledby="login-modal-title" aria-hidden="true" tabindex="-1">
+        <div class="auth-modal__content">
+            <button type="button" class="auth-modal__close" data-modal-close aria-label="Cerrar formulario de inicio de sesión">✕</button>
+            <h2 class="auth-modal__title" id="login-modal-title">Iniciar sesión</h2>
+            <p class="auth-modal__description">Accede a tu cuenta para administrar tus propiedades y tu actividad en Domably.</p>
+            <form id="login-form" class="auth-modal__form">
+                <div class="auth-modal__form-group">
+                    <label for="login-email">Correo electrónico</label>
+                    <input type="email" id="login-email" name="email" autocomplete="email" required>
+                </div>
+                <div class="auth-modal__form-group">
+                    <label for="login-password">Contraseña</label>
+                    <input type="password" id="login-password" name="password" autocomplete="current-password" required>
+                </div>
+                <button type="submit" class="header__action-btn header__action-btn--primary auth-modal__submit">Iniciar sesión</button>
+                <p class="auth-modal__message"></p>
+            </form>
+            <div class="auth-modal__footer">
+                <span>¿Aún no tienes cuenta?</span>
+                <button type="button" class="auth-modal__link" data-switch-modal="register">Crear una cuenta</button>
+            </div>
+        </div>
+    </section>
+
+    <section class="auth-modal" id="register-modal" role="dialog" aria-modal="true" aria-labelledby="register-modal-title" aria-hidden="true" tabindex="-1">
+        <div class="auth-modal__content">
+            <button type="button" class="auth-modal__close" data-modal-close aria-label="Cerrar formulario de registro">✕</button>
+            <h2 class="auth-modal__title" id="register-modal-title">Crear cuenta</h2>
+            <p class="auth-modal__description">Únete a Domably para publicar propiedades, guardarlas como favoritas y seguir tu actividad.</p>
+            <form id="register-form" class="auth-modal__form">
+                <div class="auth-modal__form-group">
+                    <label for="register-name">Nombre completo</label>
+                    <input type="text" id="register-name" name="name" autocomplete="name" required>
+                </div>
+                <div class="auth-modal__form-group">
+                    <label for="register-email">Correo electrónico</label>
+                    <input type="email" id="register-email" name="email" autocomplete="email" required>
+                </div>
+                <div class="auth-modal__form-group">
+                    <label for="register-phone">Teléfono</label>
+                    <input type="tel" id="register-phone" name="phone" autocomplete="tel">
+                </div>
+                <div class="auth-modal__form-group">
+                    <label for="register-birthdate">Fecha de nacimiento</label>
+                    <input type="date" id="register-birthdate" name="birth_date" autocomplete="bday">
+                </div>
+                <div class="auth-modal__form-group">
+                    <label for="register-password">Contraseña</label>
+                    <input type="password" id="register-password" name="password" autocomplete="new-password" minlength="6" required>
+                </div>
+                <div class="auth-modal__form-group">
+                    <label for="register-confirm-password">Confirmar contraseña</label>
+                    <input type="password" id="register-confirm-password" name="confirm_password" autocomplete="new-password" minlength="6" required>
+                </div>
+                <button type="submit" class="header__action-btn header__action-btn--primary auth-modal__submit">Crear cuenta</button>
+                <p class="auth-modal__message"></p>
+            </form>
+            <div class="auth-modal__footer">
+                <span>¿Ya tienes una cuenta?</span>
+                <button type="button" class="auth-modal__link" data-switch-modal="login">Iniciar sesión</button>
+            </div>
+        </div>
+    </section>
+
     <script src="assets/js/main.js"></script>
-    <script src="assets/js/app.js"></script> 
+    <script src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add login and register buttons to the desktop header and mobile drawer with a dynamic "Mi cuenta" link
- embed modal forms for logging in and registering users that integrate with the existing auth API
- style the new actions and modals and extend main.js to manage auth state, JWT storage, and modal behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb67f58ae48320b958d55957b526f6