### PR TITLE
Add authentication modal and client login flows

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5096,3 +5096,206 @@ body:not(.home) .header__action-button--register {
 .mobile-nav__auth-text {
     font-size: 1rem;
 }
+
+.mobile-nav__auth-link--logout {
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.mobile-nav__auth-link--logout .mobile-nav__auth-text {
+    font-weight: 600;
+}
+
+/* ======================== */
+/* ====== AUTH MODAL ====== */
+/* ======================== */
+
+.auth-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    opacity: 0;
+    pointer-events: none;
+    transform: scale(0.98);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    z-index: 1001;
+}
+
+.auth-modal--visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale(1);
+}
+
+.auth-modal__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 1000;
+}
+
+.auth-modal__overlay--visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+body.auth-modal-open {
+    overflow: hidden;
+}
+
+.auth-modal__content {
+    background: #ffffff;
+    border-radius: 18px;
+    max-width: 520px;
+    width: 100%;
+    padding: 2rem;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+    position: relative;
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+.auth-modal__close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    border: none;
+    background: transparent;
+    font-size: 2rem;
+    line-height: 1;
+    color: #0f172a;
+    cursor: pointer;
+}
+
+.auth-modal__header {
+    text-align: center;
+    margin-bottom: 1.5rem;
+}
+
+.auth-modal__title {
+    font-size: 1.75rem;
+    margin-bottom: 0.4rem;
+    color: #0f172a;
+}
+
+.auth-modal__subtitle {
+    font-size: 1rem;
+    color: #475569;
+}
+
+.auth-modal__tabs {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+    margin-bottom: 1.75rem;
+    background: #f1f5f9;
+    padding: 0.35rem;
+    border-radius: 999px;
+}
+
+.auth-modal__tab {
+    border: none;
+    background: transparent;
+    border-radius: 999px;
+    padding: 0.65rem 1.25rem;
+    font-weight: 600;
+    color: #475569;
+    cursor: pointer;
+    transition: background 0.25s ease, color 0.25s ease;
+}
+
+.auth-modal__tab--active {
+    background: linear-gradient(135deg, #0ea5e9, #2563eb);
+    color: #ffffff;
+    box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.auth-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.auth-form__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 640px) {
+    .auth-form__grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.auth-form__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.auth-form__group label {
+    font-weight: 600;
+    color: #0f172a;
+    font-size: 0.95rem;
+}
+
+.auth-form__group input {
+    border: 1px solid #cbd5f5;
+    border-radius: 12px;
+    padding: 0.75rem 0.9rem;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-form__group input:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.1);
+    outline: none;
+}
+
+.auth-form__submit {
+    margin-top: 0.5rem;
+    background: linear-gradient(135deg, #0ea5e9, #2563eb);
+    border: none;
+    border-radius: 999px;
+    padding: 0.85rem 1.5rem;
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-form__submit:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+    box-shadow: none;
+}
+
+.auth-form__submit:not(:disabled):hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+.auth-modal__message {
+    margin-top: 1rem;
+    font-size: 0.95rem;
+    text-align: center;
+    color: #0f172a;
+    min-height: 1.2rem;
+}
+
+.auth-modal__message--error {
+    color: #dc2626;
+}
+
+.auth-modal__message--success {
+    color: #16a34a;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,9 +22,10 @@
                         <h1 class="header__title sr-only">DOMABLY</h1>
                     </a>
                 </div>
-                <div class="header__actions">
-                    <a href="login.html" class="header__action-button header__action-button--login">Iniciar Sesión</a>
-                    <a href="register.html" class="header__action-button header__action-button--register">Registrar</a>
+                <div class="header__actions" data-auth-controls>
+                    <a href="#" class="header__action-button header__action-button--login" data-auth-trigger="login">Iniciar Sesión</a>
+                    <a href="#" class="header__action-button header__action-button--register" data-auth-trigger="register">Registrar</a>
+                    <a href="feed.html" class="header__action-button header__action-button--profile" data-auth-profile hidden>Mi perfil</a>
                 </div>
             </div>
             <hr class="header__divider">
@@ -45,12 +46,21 @@
                         <span class="mobile-nav__title">Tu propiedad ideal</span>
                         <span class="mobile-nav__close-button">✕</span>
                     </li>
-                    <div class="mobile-nav__btn">
-                        <a href="admin/" class="mobile-nav__auth-link">
+                    <div class="mobile-nav__btn" data-auth-controls>
+                        <a href="#" class="mobile-nav__auth-link mobile-nav__auth-link--login" data-auth-trigger="login">
                             <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M12 2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4zm-6 4c.22-.72 2.31-1.25 6-1.25s5.78.53 6 1.25z"/>
                             </svg>
-                            <span class="mobile-nav__auth-text">Log in / Register</span>
+                            <span class="mobile-nav__auth-text">Iniciar Sesión / Registrar</span>
+                        </a>
+                        <a href="feed.html" class="mobile-nav__auth-link mobile-nav__auth-link--profile" data-auth-profile hidden>
+                            <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4zm-6 4c.22-.72 2.31-1.25 6-1.25s5.78.53 6 1.25z"/>
+                            </svg>
+                            <span class="mobile-nav__auth-text">Mi perfil</span>
+                        </a>
+                        <a href="#" class="mobile-nav__auth-link mobile-nav__auth-link--logout" data-auth-logout hidden>
+                            <span class="mobile-nav__auth-text">Cerrar sesión</span>
                         </a>
                     </div>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="index.html"><img src="assets/images/iconcaracteristic/home-icon.png" alt="Inicio Icon" class="mobile-nav__icon">Inicio</a></li>
@@ -221,7 +231,63 @@
         </div>
     </footer>
 
+    <div class="auth-modal" id="auth-modal" aria-hidden="true" role="dialog" aria-labelledby="auth-modal-title">
+        <div class="auth-modal__content">
+            <button class="auth-modal__close" type="button" aria-label="Cerrar" data-auth-close>&times;</button>
+            <div class="auth-modal__header">
+                <h2 class="auth-modal__title" id="auth-modal-title">Bienvenido a Domably</h2>
+                <p class="auth-modal__subtitle">Crea tu cuenta o inicia sesión para continuar</p>
+            </div>
+            <div class="auth-modal__tabs">
+                <button class="auth-modal__tab auth-modal__tab--active" type="button" data-auth-tab="login">Iniciar Sesión</button>
+                <button class="auth-modal__tab" type="button" data-auth-tab="register">Registrarme</button>
+            </div>
+            <form class="auth-form auth-form--login" id="auth-login-form" autocomplete="on">
+                <div class="auth-form__group">
+                    <label for="login-email">Correo electrónico</label>
+                    <input type="email" id="login-email" name="email" placeholder="correo@dominio.com" required>
+                </div>
+                <div class="auth-form__group">
+                    <label for="login-password">Contraseña</label>
+                    <input type="password" id="login-password" name="password" placeholder="••••••••" minlength="6" required>
+                </div>
+                <button type="submit" class="auth-form__submit">Iniciar sesión</button>
+            </form>
+            <form class="auth-form auth-form--register" id="auth-register-form" autocomplete="on" hidden>
+                <div class="auth-form__grid">
+                    <div class="auth-form__group">
+                        <label for="register-name">Nombre completo</label>
+                        <input type="text" id="register-name" name="name" placeholder="Tu nombre" required>
+                    </div>
+                    <div class="auth-form__group">
+                        <label for="register-email">Correo electrónico</label>
+                        <input type="email" id="register-email" name="email" placeholder="correo@dominio.com" required>
+                    </div>
+                    <div class="auth-form__group">
+                        <label for="register-phone">Teléfono</label>
+                        <input type="tel" id="register-phone" name="phone" placeholder="000 000 0000">
+                    </div>
+                    <div class="auth-form__group">
+                        <label for="register-birth">Fecha de nacimiento</label>
+                        <input type="date" id="register-birth" name="birth_date">
+                    </div>
+                    <div class="auth-form__group">
+                        <label for="register-password">Contraseña</label>
+                        <input type="password" id="register-password" name="password" placeholder="••••••••" minlength="6" required>
+                    </div>
+                    <div class="auth-form__group">
+                        <label for="register-password-confirm">Confirmar contraseña</label>
+                        <input type="password" id="register-password-confirm" name="password_confirm" placeholder="••••••••" minlength="6" required>
+                    </div>
+                </div>
+                <button type="submit" class="auth-form__submit">Crear cuenta</button>
+            </form>
+            <p class="auth-modal__message" id="auth-form-message" role="alert" aria-live="polite"></p>
+        </div>
+    </div>
+    <div class="auth-modal__overlay" id="auth-modal-overlay" data-auth-close></div>
+
     <script src="assets/js/main.js"></script>
-    <script src="assets/js/app.js"></script> 
+    <script src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace header and mobile navigation login links with authentication controls that swap to a profile link after login
- add a reusable login/register modal with styles and client-side validation that integrates with the existing auth API
- persist JWT based sessions on the client, decoding the token to show admin or user specific destinations and provide a logout action on mobile

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce23ac80bc83208c8cc1c010f795c4