### PR TITLE
Add login modal and authentication UI handling

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5096,3 +5096,182 @@ body:not(.home) .header__action-button--register {
 .mobile-nav__auth-text {
     font-size: 1rem;
 }
+
+.is-hidden {
+    display: none !important;
+}
+
+.auth-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    z-index: 2000;
+}
+
+.auth-modal.is-open {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+.auth-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(3px);
+}
+
+.auth-modal__content {
+    position: relative;
+    z-index: 1;
+    width: min(420px, 100%);
+    background: #ffffff;
+    border-radius: 18px;
+    padding: 2.5rem 2.25rem;
+    box-shadow: 0 30px 70px rgba(15, 23, 42, 0.18);
+}
+
+.auth-modal__close {
+    position: absolute;
+    top: 1.25rem;
+    right: 1.25rem;
+    background: rgba(15, 23, 42, 0.06);
+    border: none;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: #111827;
+    cursor: pointer;
+    transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.auth-modal__close:hover {
+    background: rgba(15, 23, 42, 0.12);
+    transform: scale(1.05);
+}
+
+.auth-modal__header {
+    margin-bottom: 1.75rem;
+    text-align: left;
+}
+
+.auth-modal__title {
+    font-size: 1.8rem;
+    margin-bottom: 0.35rem;
+    color: #0f172a;
+    font-weight: 700;
+}
+
+.auth-modal__subtitle {
+    font-size: 0.95rem;
+    color: #4b5563;
+}
+
+.auth-modal__form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.auth-modal__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.auth-modal__field label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.auth-modal__field input {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border: 1px solid #d1d5db;
+    border-radius: 10px;
+    font-size: 0.95rem;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.auth-modal__field input:focus {
+    outline: none;
+    border-color: #0ea5e9;
+    box-shadow: 0 0 0 4px rgba(14, 165, 233, 0.15);
+}
+
+.auth-modal__feedback {
+    min-height: 1.25rem;
+    font-size: 0.85rem;
+    color: #dc2626;
+}
+
+.auth-modal__feedback--success {
+    color: #059669;
+}
+
+.auth-modal__submit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: linear-gradient(135deg, #0ea5e9, #2563eb);
+    color: #ffffff;
+    border: none;
+    border-radius: 999px;
+    padding: 0.9rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.3s ease;
+}
+
+.auth-modal__submit:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 15px 30px rgba(37, 99, 235, 0.25);
+}
+
+.auth-modal__submit:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+    box-shadow: none;
+}
+
+.auth-modal__register-hint {
+    text-align: center;
+    font-size: 0.9rem;
+    color: #4b5563;
+}
+
+.auth-modal__register-hint a {
+    color: #2563eb;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.auth-modal__register-hint a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 540px) {
+    .auth-modal {
+        padding: 1.5rem;
+    }
+
+    .auth-modal__content {
+        padding: 2rem 1.75rem;
+    }
+
+    .auth-modal__title {
+        font-size: 1.6rem;
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,8 +23,9 @@
                     </a>
                 </div>
                 <div class="header__actions">
-                    <a href="login.html" class="header__action-button header__action-button--login">Iniciar Sesión</a>
-                    <a href="register.html" class="header__action-button header__action-button--register">Registrar</a>
+                    <a href="#" class="header__action-button header__action-button--login" data-login-trigger data-auth-state="guest">Iniciar Sesión</a>
+                    <a href="register.html" class="header__action-button header__action-button--register" data-auth-state="guest">Registrar</a>
+                    <a href="admin/index.php" class="header__action-button header__action-button--profile is-hidden" data-auth-state="authenticated">Mi Perfil</a>
                 </div>
             </div>
             <hr class="header__divider">
@@ -45,8 +46,8 @@
                         <span class="mobile-nav__title">Tu propiedad ideal</span>
                         <span class="mobile-nav__close-button">✕</span>
                     </li>
-                    <div class="mobile-nav__btn">
-                        <a href="admin/" class="mobile-nav__auth-link">
+                    <div class="mobile-nav__btn" data-auth-state="guest">
+                        <a href="#" class="mobile-nav__auth-link" data-login-trigger>
                             <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M12 2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4zm-6 4c.22-.72 2.31-1.25 6-1.25s5.78.53 6 1.25z"/>
                             </svg>
@@ -58,7 +59,7 @@
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="contact.php"><img src="assets/images/iconcaracteristic/contact-icon.png" alt="Contacto Icon" class="mobile-nav__icon">Contacto</a></li>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="about.php"><img src="assets/images/iconcaracteristic/about-icon.png" alt="Sobre Nosotros Icon" class="mobile-nav__icon">Sobre Nosotros</a></li>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="join.php"><img src="assets/images/iconcaracteristic/join-icon.png" alt="Únete a Nosotros Icon" class="mobile-nav__icon">Únete a Nosotros</a></li>
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="admin/index.php"><img src="assets/images/iconcaracteristic/account-icon.png" alt="Mi Cuenta Icon" class="mobile-nav__icon">Mi Cuenta</a></li>
+                    <li class="mobile-nav__item is-hidden" data-auth-state="authenticated"><a class="mobile-nav__link" href="admin/index.php"><img src="assets/images/iconcaracteristic/account-icon.png" alt="Mi Cuenta Icon" class="mobile-nav__icon">Mi Perfil</a></li>
                 </ul>
             </nav>
         </div>
@@ -221,7 +222,31 @@
         </div>
     </footer>
 
+    <div class="auth-modal" id="login-modal" aria-hidden="true">
+        <div class="auth-modal__overlay" data-login-close></div>
+        <div class="auth-modal__content" role="dialog" aria-modal="true" aria-labelledby="login-modal-title">
+            <button class="auth-modal__close" type="button" aria-label="Cerrar" data-login-close>×</button>
+            <div class="auth-modal__header">
+                <h2 class="auth-modal__title" id="login-modal-title">Iniciar Sesión</h2>
+                <p class="auth-modal__subtitle">Ingresa tus credenciales para acceder a tu cuenta.</p>
+            </div>
+            <form class="auth-modal__form" id="login-form" novalidate>
+                <div class="auth-modal__field">
+                    <label for="login-email">Correo electrónico</label>
+                    <input type="email" id="login-email" name="email" placeholder="tu@correo.com" required>
+                </div>
+                <div class="auth-modal__field">
+                    <label for="login-password">Contraseña</label>
+                    <input type="password" id="login-password" name="password" placeholder="••••••••" required>
+                </div>
+                <div class="auth-modal__feedback" id="login-feedback" role="alert" aria-live="polite"></div>
+                <button type="submit" class="auth-modal__submit">Ingresar</button>
+                <p class="auth-modal__register-hint">¿Aún no tienes cuenta? <a href="register.html">Regístrate aquí</a>.</p>
+            </form>
+        </div>
+    </div>
+
     <script src="assets/js/main.js"></script>
-    <script src="assets/js/app.js"></script> 
+    <script src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable login modal to the home page and guard profile links behind authentication
- add styling for the modal along with helper classes for authenticated and guest states
- implement frontend logic to manage modal interactions, call the login API, and toggle navigation visibility based on the JWT token

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf1c5f540c8320be22c0182228fda1