### PR TITLE
Add login modal and integrate frontend auth flow

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -174,6 +174,10 @@ body:not(.home){
     border-radius: 5px;
 }
 
+.is-hidden {
+    display: none !important;
+}
+
 /* Ajustar el botón de cerrar para no interferir con los íconos */
 .mobile-nav__close-button {
     position: absolute;
@@ -5174,4 +5178,188 @@ body:not(.home) .header__action-button--register {
 
 .mobile-nav__arrow-icon.open {
     transform: rotate(180deg);
+}
+
+/* ================================================= */
+/* === MODAL DE AUTENTICACIÓN === */
+/* ================================================= */
+
+.auth-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    z-index: 200;
+}
+
+.auth-modal--visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+.auth-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+}
+
+.auth-modal__dialog {
+    position: relative;
+    z-index: 1;
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 30px 60px rgba(14, 30, 37, 0.3);
+    width: min(480px, 90%);
+    padding: 32px 36px;
+    animation: fadeIn 0.3s ease;
+}
+
+.auth-modal__close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    background: transparent;
+    border: none;
+    font-size: 28px;
+    color: #7f8c8d;
+    cursor: pointer;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.auth-modal__close:hover {
+    color: #2c3e50;
+    transform: scale(1.1);
+}
+
+.auth-modal__tabs {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+    background: #f4f6f8;
+    border-radius: 12px;
+    padding: 6px;
+    margin-bottom: 24px;
+}
+
+.auth-modal__tab {
+    background: transparent;
+    border: none;
+    font-weight: 600;
+    font-size: 15px;
+    padding: 10px 16px;
+    border-radius: 10px;
+    color: #7f8c8d;
+    cursor: pointer;
+    transition: background 0.25s ease, color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.auth-modal__tab--active {
+    background: linear-gradient(135deg, #1a73e8, #103cbe);
+    color: #ffffff;
+    box-shadow: 0 10px 20px rgba(16, 60, 190, 0.25);
+}
+
+.auth-form {
+    display: none;
+}
+
+.auth-form--active {
+    display: block;
+}
+
+.auth-form__title {
+    font-size: 24px;
+    margin-bottom: 6px;
+    color: #2c3e50;
+    font-weight: 700;
+}
+
+.auth-form__subtitle {
+    font-size: 15px;
+    color: #7f8c8d;
+    margin-bottom: 24px;
+}
+
+.auth-form__group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 16px;
+}
+
+.auth-form__label {
+    font-size: 14px;
+    font-weight: 600;
+    color: #546e7a;
+}
+
+.auth-form__input {
+    width: 100%;
+    padding: 12px 14px;
+    border: 1px solid #dfe6eb;
+    border-radius: 10px;
+    background: #fdfdfd;
+    font-size: 15px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-form__input:focus {
+    outline: none;
+    border-color: #1a73e8;
+    box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.1);
+}
+
+.auth-form__submit {
+    width: 100%;
+    padding: 14px 16px;
+    border: none;
+    border-radius: 12px;
+    background: linear-gradient(135deg, #1a73e8, #103cbe);
+    color: #ffffff;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-form__submit:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 15px 25px rgba(26, 115, 232, 0.35);
+}
+
+.auth-form__submit:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.auth-form__message {
+    min-height: 20px;
+    font-size: 14px;
+    margin-bottom: 12px;
+}
+
+.auth-form__message--error {
+    color: #d90429;
+}
+
+.auth-form__message--success {
+    color: #2e7d32;
+}
+
+@media (max-width: 600px) {
+    .auth-modal__dialog {
+        padding: 28px 22px;
+    }
+
+    .auth-form__title {
+        font-size: 22px;
+    }
+
+    .auth-form__submit {
+        font-size: 15px;
+    }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,9 +23,9 @@
                     </a>
                 </div>
                 <div class="header__actions">
-                    <a href="login.html" class="header__action-button header__action-button--login">Iniciar Sesión</a>
-                    <a href="register.html" class="header__action-button header__action-button--register">Registrar</a>
-                    <a href="profile.html" class="header__action-button header__action-button--profile">
+                    <a href="#" data-auth-trigger="login" data-auth-section="guest" class="header__action-button header__action-button--login">Iniciar Sesión</a>
+                    <a href="#" data-auth-trigger="register" data-auth-section="guest" class="header__action-button header__action-button--register">Registrar</a>
+                    <a href="profile.html" data-auth-section="profile" class="header__action-button header__action-button--profile is-hidden">
                         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 8px;">
                             <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
                             <circle cx="12" cy="7" r="4"></circle>
@@ -53,14 +53,14 @@
                         <span class="mobile-nav__close-button">✕</span>
                     </li>
                     <div class="mobile-nav__btn">
-                        <a href="admin/" class="mobile-nav__auth-link">
+                        <a href="#" data-auth-trigger="login" data-auth-section="guest" class="mobile-nav__auth-link">
                             <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M12 2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4zm-6 4c.22-.72 2.31-1.25 6-1.25s5.78.53 6 1.25z"/>
                             </svg>
                             <span class="mobile-nav__auth-text">Log in / Register</span>
                         </a>
                     </div>
-                    <div class="mobile-nav__profile-section">
+                    <div class="mobile-nav__profile-section is-hidden" data-auth-section="profile">
                         <a href="#" id="profile-button" class="mobile-nav__auth-link">
                             <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
@@ -204,6 +204,61 @@
                 </div>
         </div>
     </section>
+
+    <div class="auth-modal" id="auth-modal" aria-hidden="true" role="dialog" aria-labelledby="auth-modal-title">
+        <div class="auth-modal__overlay" data-auth-close></div>
+        <div class="auth-modal__dialog" role="document">
+            <button class="auth-modal__close" type="button" aria-label="Cerrar" data-auth-close>&times;</button>
+            <div class="auth-modal__content">
+                <div class="auth-modal__tabs" role="tablist">
+                    <button class="auth-modal__tab auth-modal__tab--active" type="button" role="tab" aria-selected="true" data-auth-tab="login">Iniciar Sesión</button>
+                    <button class="auth-modal__tab" type="button" role="tab" aria-selected="false" data-auth-tab="register">Registrar</button>
+                </div>
+                <div class="auth-modal__forms">
+                    <form id="login-form" class="auth-form auth-form--active" novalidate>
+                        <h2 class="auth-form__title" id="auth-modal-title">Bienvenido de nuevo</h2>
+                        <p class="auth-form__subtitle">Ingresa tus credenciales para continuar.</p>
+                        <div class="auth-form__group">
+                            <label for="login-email" class="auth-form__label">Correo electrónico</label>
+                            <input id="login-email" name="email" type="email" class="auth-form__input" placeholder="tu@correo.com" required>
+                        </div>
+                        <div class="auth-form__group">
+                            <label for="login-password" class="auth-form__label">Contraseña</label>
+                            <input id="login-password" name="password" type="password" class="auth-form__input" placeholder="••••••••" required>
+                        </div>
+                        <div class="auth-form__message" data-auth-message="login"></div>
+                        <button type="submit" class="auth-form__submit">Iniciar Sesión</button>
+                    </form>
+                    <form id="register-form" class="auth-form" novalidate>
+                        <h2 class="auth-form__title">Crea tu cuenta</h2>
+                        <p class="auth-form__subtitle">Completa los datos para unirte a Domably.</p>
+                        <div class="auth-form__group">
+                            <label for="register-name" class="auth-form__label">Nombre completo</label>
+                            <input id="register-name" name="name" type="text" class="auth-form__input" placeholder="Tu nombre" required>
+                        </div>
+                        <div class="auth-form__group">
+                            <label for="register-email" class="auth-form__label">Correo electrónico</label>
+                            <input id="register-email" name="email" type="email" class="auth-form__input" placeholder="tu@correo.com" required>
+                        </div>
+                        <div class="auth-form__group">
+                            <label for="register-password" class="auth-form__label">Contraseña</label>
+                            <input id="register-password" name="password" type="password" class="auth-form__input" placeholder="Crea una contraseña" required>
+                        </div>
+                        <div class="auth-form__group">
+                            <label for="register-phone" class="auth-form__label">Teléfono (opcional)</label>
+                            <input id="register-phone" name="phone" type="tel" class="auth-form__input" placeholder="55 1234 5678">
+                        </div>
+                        <div class="auth-form__group">
+                            <label for="register-birth" class="auth-form__label">Fecha de nacimiento (opcional)</label>
+                            <input id="register-birth" name="birth_date" type="date" class="auth-form__input">
+                        </div>
+                        <div class="auth-form__message" data-auth-message="register"></div>
+                        <button type="submit" class="auth-form__submit">Crear cuenta</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <footer class="site-footer">
         <div class="container">


### PR DESCRIPTION
## Summary
- add a dual-mode authentication modal on the homepage and hook existing header/mobile actions to open it
- implement styling for the modal and shared helpers to hide or show guest/profile navigation entries based on login state
- connect the modal forms to the existing backend login and register endpoints, persisting the token and updating the UI accordingly

## Testing
- not run (frontend-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cf1ea85fec8320a45dba191abb856c