### PR TITLE
Refine authentication modal layout

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5210,12 +5210,94 @@ body:not(.home) .header__action-button--register {
 .auth-modal__dialog {
     position: relative;
     z-index: 1;
-    background: #ffffff;
-    border-radius: 16px;
+    border-radius: 20px;
     box-shadow: 0 30px 60px rgba(14, 30, 37, 0.3);
-    width: min(480px, 90%);
-    padding: 32px 36px;
+    width: min(960px, 94%);
+    padding: 0;
+    background: transparent;
     animation: fadeIn 0.3s ease;
+    overflow: hidden;
+}
+
+.auth-modal__layout {
+    display: grid;
+    grid-template-columns: 320px minmax(0, 1fr);
+    background: #ffffff;
+    border-radius: 20px;
+    overflow: hidden;
+}
+
+.auth-modal__illustration {
+    position: relative;
+    padding: 42px 36px 48px;
+    background: linear-gradient(135deg, rgba(16, 60, 190, 0.9), rgba(26, 115, 232, 0.9)), url('../images/hero/placeholder3.jpg') center/cover;
+    color: #ffffff;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    isolation: isolate;
+}
+
+.auth-modal__illustration::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.25), transparent 60%);
+    z-index: -1;
+}
+
+.auth-modal__brand {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.auth-modal__brand-logo {
+    width: 120px;
+    height: auto;
+}
+
+.auth-modal__brand-text {
+    font-size: 16px;
+    line-height: 1.5;
+    opacity: 0.9;
+}
+
+.auth-modal__benefits {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    font-size: 15px;
+    line-height: 1.5;
+}
+
+.auth-modal__benefits li {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.auth-modal__benefits li::before {
+    content: "✔";
+    font-size: 14px;
+    margin-top: 3px;
+    color: #a8d5ff;
+}
+
+.auth-modal__content {
+    padding: 40px 48px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.auth-modal__forms {
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
 }
 
 .auth-modal__close {
@@ -5284,11 +5366,112 @@ body:not(.home) .header__action-button--register {
     margin-bottom: 24px;
 }
 
+.auth-form__social {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 18px;
+}
+
+.auth-form__social--compact {
+    gap: 10px;
+}
+
+.auth-form__social-button {
+    flex: 1 1 calc(50% - 6px);
+    min-width: 180px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    border-radius: 12px;
+    border: 1px solid rgba(16, 60, 190, 0.15);
+    padding: 12px 16px;
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+    color: #1a237e;
+    background: #f4f7ff;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.auth-form__social-button--google {
+    background: linear-gradient(135deg, #f8fbff, #e2ecff);
+}
+
+.auth-form__social-button--linkedin {
+    background: linear-gradient(135deg, #e5f1ff, #c8dcff);
+}
+
+.auth-form__social-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 20px rgba(26, 115, 232, 0.18);
+}
+
+.auth-form__social-button:focus-visible {
+    outline: 3px solid rgba(26, 115, 232, 0.35);
+    outline-offset: 2px;
+}
+
+.auth-form__social-icon {
+    font-size: 16px;
+}
+
+.auth-form__divider {
+    position: relative;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #90a4ae;
+    text-align: center;
+    margin-bottom: 18px;
+}
+
+.auth-form__divider::before,
+.auth-form__divider::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 36%;
+    height: 1px;
+    background: #e0e6ed;
+}
+
+.auth-form__divider::before {
+    left: 0;
+}
+
+.auth-form__divider::after {
+    right: 0;
+}
+
 .auth-form__group {
     display: flex;
     flex-direction: column;
     gap: 6px;
     margin-bottom: 16px;
+}
+
+.auth-form__actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.auth-form__checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: #607d8b;
+}
+
+.auth-form__checkbox input {
+    width: 16px;
+    height: 16px;
+    accent-color: #1a73e8;
 }
 
 .auth-form__label {
@@ -5311,6 +5494,17 @@ body:not(.home) .header__action-button--register {
     outline: none;
     border-color: #1a73e8;
     box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.1);
+}
+
+.auth-form__link {
+    color: #1a73e8;
+    font-weight: 600;
+    text-decoration: none;
+    font-size: 13px;
+}
+
+.auth-form__link:hover {
+    text-decoration: underline;
 }
 
 .auth-form__submit {
@@ -5342,6 +5536,13 @@ body:not(.home) .header__action-button--register {
     margin-bottom: 12px;
 }
 
+.auth-form__terms {
+    font-size: 13px;
+    color: #78909c;
+    line-height: 1.6;
+    margin-top: 18px;
+}
+
 .auth-form__message--error {
     color: #d90429;
 }
@@ -5350,13 +5551,31 @@ body:not(.home) .header__action-button--register {
     color: #2e7d32;
 }
 
+@media (max-width: 960px) {
+    .auth-modal__layout {
+        grid-template-columns: 1fr;
+    }
+
+    .auth-modal__illustration {
+        display: none;
+    }
+
+    .auth-modal__content {
+        padding: 36px 28px;
+    }
+}
+
 @media (max-width: 600px) {
-    .auth-modal__dialog {
+    .auth-modal__content {
         padding: 28px 22px;
     }
 
     .auth-form__title {
         font-size: 22px;
+    }
+
+    .auth-form__social-button {
+        flex: 1 1 100%;
     }
 
     .auth-form__submit {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -209,15 +209,38 @@
         <div class="auth-modal__overlay" data-auth-close></div>
         <div class="auth-modal__dialog" role="document">
             <button class="auth-modal__close" type="button" aria-label="Cerrar" data-auth-close>&times;</button>
-            <div class="auth-modal__content">
-                <div class="auth-modal__tabs" role="tablist">
-                    <button class="auth-modal__tab auth-modal__tab--active" type="button" role="tab" aria-selected="true" data-auth-tab="login">Iniciar Sesión</button>
-                    <button class="auth-modal__tab" type="button" role="tab" aria-selected="false" data-auth-tab="register">Registrar</button>
-                </div>
-                <div class="auth-modal__forms">
-                    <form id="login-form" class="auth-form auth-form--active" novalidate>
+            <div class="auth-modal__layout">
+                <aside class="auth-modal__illustration" aria-hidden="true">
+                    <div class="auth-modal__brand">
+                        <img src="assets/images/iconcaracteristic/logo-light.png" alt="Domably" class="auth-modal__brand-logo">
+                        <p class="auth-modal__brand-text">Experiencias inmobiliarias premium para compradores y asesores.</p>
+                    </div>
+                    <ul class="auth-modal__benefits">
+                        <li>Accede a propiedades exclusivas y oportunidades de inversión.</li>
+                        <li>Guarda tus favoritos y retoma tu búsqueda en cualquier dispositivo.</li>
+                        <li>Recibe asesoría personalizada por parte de nuestro equipo experto.</li>
+                    </ul>
+                </aside>
+                <div class="auth-modal__content">
+                    <div class="auth-modal__tabs" role="tablist">
+                        <button class="auth-modal__tab auth-modal__tab--active" type="button" role="tab" aria-selected="true" data-auth-tab="login">Iniciar Sesión</button>
+                        <button class="auth-modal__tab" type="button" role="tab" aria-selected="false" data-auth-tab="register">Registrar</button>
+                    </div>
+                    <div class="auth-modal__forms" role="presentation">
+                        <form id="login-form" class="auth-form auth-form--active" novalidate>
                         <h2 class="auth-form__title" id="auth-modal-title">Bienvenido de nuevo</h2>
                         <p class="auth-form__subtitle">Ingresa tus credenciales para continuar.</p>
+                        <div class="auth-form__social">
+                            <button type="button" class="auth-form__social-button auth-form__social-button--google">
+                                <span class="auth-form__social-icon" aria-hidden="true">🔐</span>
+                                Continuar con Google
+                            </button>
+                            <button type="button" class="auth-form__social-button auth-form__social-button--linkedin">
+                                <span class="auth-form__social-icon" aria-hidden="true">💼</span>
+                                Continuar con LinkedIn
+                            </button>
+                        </div>
+                        <div class="auth-form__divider" role="separator">o continúa con tu correo</div>
                         <div class="auth-form__group">
                             <label for="login-email" class="auth-form__label">Correo electrónico</label>
                             <input id="login-email" name="email" type="email" class="auth-form__input" placeholder="tu@correo.com" required>
@@ -226,12 +249,31 @@
                             <label for="login-password" class="auth-form__label">Contraseña</label>
                             <input id="login-password" name="password" type="password" class="auth-form__input" placeholder="••••••••" required>
                         </div>
+                        <div class="auth-form__actions">
+                            <label class="auth-form__checkbox">
+                                <input type="checkbox" name="remember">
+                                <span>Recordarme</span>
+                            </label>
+                            <a href="#" class="auth-form__link">¿Olvidaste tu contraseña?</a>
+                        </div>
                         <div class="auth-form__message" data-auth-message="login"></div>
                         <button type="submit" class="auth-form__submit">Iniciar Sesión</button>
                     </form>
-                    <form id="register-form" class="auth-form" novalidate>
+
+                        <form id="register-form" class="auth-form" novalidate>
                         <h2 class="auth-form__title">Crea tu cuenta</h2>
                         <p class="auth-form__subtitle">Completa los datos para unirte a Domably.</p>
+                        <div class="auth-form__social auth-form__social--compact">
+                            <button type="button" class="auth-form__social-button auth-form__social-button--google">
+                                <span class="auth-form__social-icon" aria-hidden="true">🔐</span>
+                                Google
+                            </button>
+                            <button type="button" class="auth-form__social-button auth-form__social-button--linkedin">
+                                <span class="auth-form__social-icon" aria-hidden="true">💼</span>
+                                LinkedIn
+                            </button>
+                        </div>
+                        <div class="auth-form__divider" role="separator">o crea tu cuenta manualmente</div>
                         <div class="auth-form__group">
                             <label for="register-name" class="auth-form__label">Nombre completo</label>
                             <input id="register-name" name="name" type="text" class="auth-form__input" placeholder="Tu nombre" required>
@@ -254,7 +296,9 @@
                         </div>
                         <div class="auth-form__message" data-auth-message="register"></div>
                         <button type="submit" class="auth-form__submit">Crear cuenta</button>
+                        <p class="auth-form__terms">Al registrarte aceptas nuestros <a href="#" class="auth-form__link">Términos y Condiciones</a> y la <a href="#" class="auth-form__link">Política de privacidad</a>.</p>
                     </form>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- redesign the authentication modal markup to include an illustrated brand column, social login actions, and extra contextual messaging
- enhance the login and registration forms with remember-me, recovery links, and terms copy for a more polished experience
- expand the modal styling with new gradients, responsive layout rules, and styled social buttons to deliver a professional presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf2230905483208107c911f33b6422