### PR TITLE
feat: add responsive registration experience

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5451,3 +5451,448 @@ body.auth-modal-open {
         width: 100%;
     }
 }
+/* ================================================= */
+/* === PÁGINA DE REGISTRO === */
+/* ================================================= */
+body.register-page {
+    background: linear-gradient(135deg, #f5f7fa 0%, #e9ecf7 35%, #f7f1ff 100%);
+    color: #1d1f2f;
+    padding-top: 120px;
+}
+
+body.register-page header {
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(12px);
+    box-shadow: 0 12px 40px rgba(31, 45, 61, 0.08);
+}
+
+body.register-page .header__action-button--register {
+    background: #2a4be7;
+    color: #fff;
+    border: none;
+}
+
+body.register-page .header__action-button--register:hover {
+    background: #1f3bb5;
+}
+
+.register {
+    padding: 40px 0 80px;
+}
+
+.register__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    gap: 48px;
+    align-items: stretch;
+}
+
+.register__promo {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 28px;
+    padding: 48px;
+    box-shadow: 0 30px 60px rgba(61, 89, 130, 0.12);
+    position: relative;
+    overflow: hidden;
+}
+
+.register__promo::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(84, 110, 255, 0.12), transparent 55%),
+                radial-gradient(circle at bottom left, rgba(255, 130, 92, 0.08), transparent 45%);
+    pointer-events: none;
+}
+
+.register__badge {
+    display: inline-block;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(42, 75, 231, 0.12);
+    color: #2a4be7;
+    font-weight: 600;
+    margin-bottom: 24px;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    font-size: 13px;
+}
+
+.register__promo h2 {
+    font-family: 'DM Serif Display', serif;
+    font-size: clamp(32px, 4vw, 48px);
+    margin-bottom: 24px;
+    color: #121429;
+}
+
+.register__promo p {
+    font-size: 18px;
+    line-height: 1.7;
+    margin-bottom: 32px;
+    max-width: 520px;
+}
+
+.register__benefits {
+    list-style: none;
+    display: grid;
+    gap: 18px;
+    margin-bottom: 40px;
+}
+
+.register__benefits li {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    font-size: 16px;
+    color: #2e3350;
+    font-weight: 500;
+}
+
+.register__benefit-icon {
+    font-size: 26px;
+    line-height: 1;
+}
+
+.register__testimonial {
+    border-left: 4px solid #2a4be7;
+    padding-left: 24px;
+    font-style: italic;
+    color: #404560;
+}
+
+.register__testimonial cite {
+    display: block;
+    margin-top: 12px;
+    font-style: normal;
+    font-weight: 600;
+    color: #2a4be7;
+}
+
+.register__form-card {
+    background: #fff;
+    border-radius: 28px;
+    padding: 40px 48px;
+    box-shadow: 0 30px 60px rgba(31, 45, 61, 0.18);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+}
+
+.register-form__header h3 {
+    font-size: 28px;
+    margin-bottom: 8px;
+    color: #101229;
+}
+
+.register-form__header p {
+    color: #5c627e;
+    margin-bottom: 24px;
+}
+
+.register-form__progress {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 32px;
+}
+
+.register-form__progress-step {
+    background: #eef1fa;
+    color: #6b7090;
+    border-radius: 999px;
+    padding: 10px 18px;
+    font-size: 13px;
+    font-weight: 600;
+    text-align: center;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    transition: all 0.3s ease;
+}
+
+.register-form__progress-step.is-active {
+    background: #2a4be7;
+    color: #fff;
+    box-shadow: 0 10px 20px rgba(42, 75, 231, 0.25);
+}
+
+.register-form__progress-step.is-completed {
+    background: rgba(76, 201, 240, 0.16);
+    color: #1f3bb5;
+    border: 1px solid rgba(76, 201, 240, 0.6);
+}
+
+.register-form {
+    display: grid;
+    gap: 22px;
+}
+
+.register-form__group label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 10px;
+    color: #1c1f36;
+}
+
+.register-form__group input[type="text"],
+.register-form__group input[type="email"],
+.register-form__group input[type="tel"],
+.register-form__group input[type="date"],
+.register-form__group input[type="password"] {
+    width: 100%;
+    padding: 14px 16px;
+    border-radius: 14px;
+    border: 1px solid #d8dcf0;
+    background: #fbfcff;
+    font-size: 15px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.register-form__group input:focus {
+    border-color: #2a4be7;
+    box-shadow: 0 0 0 4px rgba(42, 75, 231, 0.12);
+    outline: none;
+}
+
+.register-form__group input.has-error {
+    border-color: #ff6b6b;
+    box-shadow: 0 0 0 4px rgba(255, 107, 107, 0.12);
+}
+
+.register-form__group--split {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+}
+
+.register-form__password-wrapper {
+    position: relative;
+}
+
+.register-form__toggle {
+    position: absolute;
+    top: 50%;
+    right: 14px;
+    transform: translateY(-50%);
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(42, 75, 231, 0.08);
+    color: #2a4be7;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.register-form__toggle::before {
+    content: '\1F441';
+    font-size: 18px;
+}
+
+.register-form__toggle.is-active {
+    background: #2a4be7;
+    color: #fff;
+    transform: translateY(-50%) scale(1.05);
+}
+
+.register-form__feedback {
+    font-size: 13px;
+    color: #ff5f5f;
+    margin-top: 8px;
+    display: none;
+}
+
+.register-form__feedback.is-visible {
+    display: block;
+}
+
+.register-form__group--checkbox {
+    display: flex;
+    align-items: flex-start;
+}
+
+.register-form__checkbox {
+    display: flex;
+    gap: 12px;
+    font-size: 14px;
+    color: #4a4f6f;
+}
+
+.register-form__checkbox input.has-error + span {
+    color: #ff6b6b;
+}
+
+.register-form__checkbox a {
+    color: #2a4be7;
+    font-weight: 600;
+}
+
+.register-form__strength {
+    font-size: 13px;
+    color: #6b7090;
+    margin-top: 10px;
+    font-weight: 500;
+}
+
+.register-form__strength[data-strength="intermedia"] {
+    color: #f59f00;
+}
+
+.register-form__strength[data-strength="fuerte"] {
+    color: #2a9d8f;
+}
+
+.register-form__password-rules {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 16px;
+    margin-top: 12px;
+    font-size: 13px;
+    color: #72779a;
+}
+
+.register-form__password-rules li {
+    position: relative;
+    padding-left: 18px;
+}
+
+.register-form__password-rules li::before {
+    content: '\2022';
+    position: absolute;
+    left: 0;
+    color: currentColor;
+}
+
+.register-form__password-rules li.is-valid {
+    color: #2a9d8f;
+}
+
+.register-form__message {
+    font-size: 14px;
+    font-weight: 600;
+    min-height: 20px;
+}
+
+.register-form__message--info {
+    color: #2a4be7;
+}
+
+.register-form__message--success {
+    color: #2a9d8f;
+}
+
+.register-form__message--error {
+    color: #ff6b6b;
+}
+
+.register-form__submit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 16px 20px;
+    background: linear-gradient(135deg, #2a4be7 0%, #5b7bff 100%);
+    color: #fff;
+    border: none;
+    border-radius: 16px;
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.register-form__submit:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 30px rgba(42, 75, 231, 0.3);
+}
+
+.register-form__submit:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+    transform: none;
+    box-shadow: none;
+}
+
+.register-form__spinner {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.4);
+    border-top-color: #fff;
+    animation: spin 0.9s linear infinite;
+    display: none;
+}
+
+.register-form__spinner.is-visible {
+    display: inline-flex;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.register-form__hint {
+    font-size: 14px;
+    color: #4c5170;
+    text-align: center;
+}
+
+.register-form__login-link {
+    color: #2a4be7;
+    font-weight: 600;
+}
+
+.register-form.is-success {
+    animation: fadeIn 0.8s ease both;
+}
+
+@media (max-width: 1200px) {
+    .register__layout {
+        grid-template-columns: 1fr;
+    }
+
+    .register__promo {
+        order: 2;
+        margin-top: 32px;
+    }
+}
+
+@media (max-width: 768px) {
+    body.register-page {
+        padding-top: 96px;
+    }
+
+    .register {
+        padding: 24px 0 60px;
+    }
+
+    .register__promo,
+    .register__form-card {
+        padding: 32px 28px;
+    }
+
+    .register-form__group--split {
+        grid-template-columns: 1fr;
+    }
+
+    .register-form__progress {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+}
+
+@media (max-width: 480px) {
+    .register__promo,
+    .register__form-card {
+        padding: 26px 22px;
+        border-radius: 20px;
+    }
+
+    .register-form__submit {
+        width: 100%;
+    }
+}

--- a/frontend/assets/js/register.js
+++ b/frontend/assets/js/register.js
@@ -1,0 +1,317 @@
+(function () {
+    const API_ENDPOINT = '/api/auth/register';
+
+    const state = {
+        isSubmitting: false,
+    };
+
+    const selectors = {
+        form: document.getElementById('register-form'),
+        message: document.getElementById('register-form-message'),
+        submitButton: document.getElementById('register-submit'),
+        submitText: document.querySelector('.register-form__submit-text'),
+        spinner: document.querySelector('.register-form__spinner'),
+        progressSteps: Array.from(document.querySelectorAll('.register-form__progress-step')),
+        passwordInput: document.getElementById('register-password'),
+        confirmInput: document.getElementById('register-password-confirm'),
+        phoneInput: document.getElementById('register-phone'),
+        birthdateInput: document.getElementById('register-birthdate'),
+        passwordStrength: document.getElementById('password-strength'),
+        toggles: Array.from(document.querySelectorAll('.register-form__toggle')),
+        loginLink: document.getElementById('register-login-link'),
+    };
+
+    if (!selectors.form) {
+        return;
+    }
+
+    if (selectors.birthdateInput) {
+        const today = new Date().toISOString().split('T')[0];
+        selectors.birthdateInput.setAttribute('max', today);
+    }
+
+    if (selectors.phoneInput) {
+        selectors.phoneInput.addEventListener('input', (event) => {
+            const digits = event.target.value.replace(/\D/g, '').slice(0, 10);
+            event.target.value = digits;
+        });
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const phoneRegex = /^\d{10}$/;
+
+    const feedbackElements = Array.from(document.querySelectorAll('.register-form__feedback'));
+
+    const setMessage = (message, type = 'info') => {
+        if (!selectors.message) return;
+        selectors.message.textContent = message;
+        selectors.message.className = `register-form__message register-form__message--${type}`;
+    };
+
+    const clearFeedback = () => {
+        feedbackElements.forEach((element) => {
+            element.textContent = '';
+            element.classList.remove('is-visible');
+        });
+        if (selectors.message) {
+            selectors.message.textContent = '';
+            selectors.message.className = 'register-form__message';
+        }
+    };
+
+    const setFieldFeedback = (id, message) => {
+        const feedback = feedbackElements.find((element) => element.dataset.feedbackFor === id);
+        const input = document.getElementById(id);
+        if (feedback) {
+            feedback.textContent = message;
+            feedback.classList.toggle('is-visible', Boolean(message));
+        }
+        if (input) {
+            input.classList.toggle('has-error', Boolean(message));
+        }
+    };
+
+    const setSubmitting = (submitting) => {
+        state.isSubmitting = submitting;
+        if (!selectors.submitButton) return;
+        selectors.submitButton.disabled = submitting;
+        if (selectors.spinner) {
+            selectors.spinner.classList.toggle('is-visible', submitting);
+        }
+        if (selectors.submitText) {
+            selectors.submitText.textContent = submitting ? 'Creando cuenta...' : 'Crear cuenta';
+        }
+    };
+
+    const updateProgress = (stepIndex) => {
+        selectors.progressSteps.forEach((step, index) => {
+            step.classList.toggle('is-active', index === stepIndex);
+            step.classList.toggle('is-completed', index < stepIndex);
+        });
+    };
+
+    const evaluatePassword = (password) => {
+        const rules = {
+            length: password.length >= 8,
+            number: /\d/.test(password),
+            uppercase: /[A-ZÁÉÍÓÚÜÑ]/.test(password),
+        };
+
+        Object.entries(rules).forEach(([rule, isValid]) => {
+            const ruleElement = document.querySelector(`[data-rule="${rule}"]`);
+            if (ruleElement) {
+                ruleElement.classList.toggle('is-valid', isValid);
+            }
+        });
+
+        let strengthLabel = 'Débil';
+        const score = Object.values(rules).filter(Boolean).length;
+        if (score === 3) {
+            strengthLabel = 'Fuerte';
+        } else if (score === 2) {
+            strengthLabel = 'Intermedia';
+        }
+
+        if (selectors.passwordStrength) {
+            selectors.passwordStrength.innerHTML = `Seguridad de la contraseña: <strong>${strengthLabel}</strong>`;
+            selectors.passwordStrength.dataset.strength = strengthLabel.toLowerCase();
+        }
+    };
+
+    updateProgress(0);
+    evaluatePassword(selectors.passwordInput ? selectors.passwordInput.value : '');
+
+    const togglePasswordVisibility = (inputId, trigger) => {
+        const input = document.getElementById(inputId);
+        if (!input) return;
+        const isPassword = input.type === 'password';
+        input.type = isPassword ? 'text' : 'password';
+        trigger.classList.toggle('is-active', isPassword);
+    };
+
+    const focusFirstError = () => {
+        const errorInput = selectors.form.querySelector('.has-error');
+        if (errorInput) {
+            errorInput.focus();
+        }
+    };
+
+    const validateForm = () => {
+        clearFeedback();
+        let isValid = true;
+
+        const formData = new FormData(selectors.form);
+        const name = formData.get('name').trim();
+        const email = formData.get('email').trim();
+        const phone = formData.get('phone').trim();
+        const birthDate = formData.get('birth_date');
+        const password = formData.get('password');
+        const passwordConfirm = formData.get('passwordConfirm');
+        const terms = selectors.form.querySelector('#register-terms');
+
+        if (!name) {
+            setFieldFeedback('register-name', 'Por favor ingresa tu nombre completo.');
+            isValid = false;
+        } else if (name.split(' ').length < 2) {
+            setFieldFeedback('register-name', 'Incluye al menos nombre y apellido.');
+            isValid = false;
+        }
+
+        if (!email) {
+            setFieldFeedback('register-email', 'Necesitamos tu correo electrónico.');
+            isValid = false;
+        } else if (!emailRegex.test(email)) {
+            setFieldFeedback('register-email', 'Revisa que el formato del correo sea válido.');
+            isValid = false;
+        }
+
+        if (phone && !phoneRegex.test(phone)) {
+            setFieldFeedback('register-phone', 'El teléfono debe contener 10 dígitos.');
+            isValid = false;
+        }
+
+        if (birthDate) {
+            const today = new Date();
+            const selectedDate = new Date(birthDate);
+            if (selectedDate > today) {
+                setFieldFeedback('register-birthdate', 'La fecha no puede ser futura.');
+                isValid = false;
+            }
+        }
+
+        if (!password) {
+            setFieldFeedback('register-password', 'Crea una contraseña segura.');
+            isValid = false;
+        } else {
+            const rules = [password.length >= 8, /\d/.test(password), /[A-ZÁÉÍÓÚÜÑ]/.test(password)];
+            if (rules.includes(false)) {
+                setFieldFeedback('register-password', 'Sigue las recomendaciones para una contraseña robusta.');
+                isValid = false;
+            }
+        }
+
+        if (!passwordConfirm) {
+            setFieldFeedback('register-password-confirm', 'Confirma tu contraseña.');
+            isValid = false;
+        } else if (passwordConfirm !== password) {
+            setFieldFeedback('register-password-confirm', 'Las contraseñas no coinciden.');
+            isValid = false;
+        }
+
+        if (!terms.checked) {
+            setFieldFeedback('register-terms', 'Debes aceptar los términos para continuar.');
+            isValid = false;
+        }
+
+        if (!isValid) {
+            focusFirstError();
+        }
+
+        return {
+            isValid,
+            payload: {
+                name,
+                email,
+                password,
+                phone: phone || null,
+                birth_date: birthDate || null,
+            },
+        };
+    };
+
+    selectors.toggles.forEach((toggle) => {
+        toggle.addEventListener('click', () => {
+            const inputId = toggle.dataset.toggle;
+            togglePasswordVisibility(inputId, toggle);
+        });
+    });
+
+    if (selectors.passwordInput) {
+        selectors.passwordInput.addEventListener('input', (event) => {
+            evaluatePassword(event.target.value);
+            updateProgress(event.target.value.length > 0 ? 1 : 0);
+        });
+    }
+
+    if (selectors.confirmInput) {
+        selectors.confirmInput.addEventListener('input', (event) => {
+            const isMatch = selectors.passwordInput && event.target.value === selectors.passwordInput.value;
+            const feedback = feedbackElements.find((element) => element.dataset.feedbackFor === 'register-password-confirm');
+            if (feedback) {
+                feedback.textContent = isMatch ? '' : 'Las contraseñas deben coincidir.';
+                feedback.classList.toggle('is-visible', !isMatch);
+            }
+            event.target.classList.toggle('has-error', !isMatch && event.target.value.length > 0);
+            if (isMatch) {
+                updateProgress(2);
+            }
+        });
+    }
+
+    selectors.form.addEventListener('input', (event) => {
+        if (event.target.matches('input')) {
+            const feedback = feedbackElements.find((element) => element.dataset.feedbackFor === event.target.id);
+            if (feedback && feedback.textContent) {
+                feedback.textContent = '';
+                feedback.classList.remove('is-visible');
+                event.target.classList.remove('has-error');
+            }
+        }
+    });
+
+    if (selectors.loginLink) {
+        selectors.loginLink.addEventListener('click', (event) => {
+            event.preventDefault();
+            const loginTrigger = document.getElementById('header-login-button');
+            if (loginTrigger) {
+                loginTrigger.click();
+            }
+        });
+    }
+
+    selectors.form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (state.isSubmitting) {
+            return;
+        }
+
+        const { isValid, payload } = validateForm();
+        if (!isValid) {
+            return;
+        }
+
+        setSubmitting(true);
+        setMessage('Estamos creando tu cuenta...', 'info');
+
+        try {
+            const response = await fetch(API_ENDPOINT, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+            });
+
+            const result = await response.json();
+
+            if (!response.ok) {
+                const errorMessage = result?.message || 'No pudimos completar tu registro. Inténtalo más tarde.';
+                setMessage(errorMessage, 'error');
+                updateProgress(1);
+                return;
+            }
+
+            selectors.form.reset();
+            evaluatePassword('');
+            updateProgress(selectors.progressSteps.length - 1);
+            setMessage('¡Cuenta creada con éxito! Revisa tu correo para confirmar tu registro.', 'success');
+            selectors.form.classList.add('is-success');
+        } catch (error) {
+            console.error('Error registrando usuario', error);
+            setMessage('Tuvimos un inconveniente. Por favor, verifica tu conexión e inténtalo de nuevo.', 'error');
+            updateProgress(1);
+        } finally {
+            setSubmitting(false);
+        }
+    });
+})();

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Crear cuenta - Domably</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="register-page">
+    <header>
+        <div class="container">
+            <div class="header__top">
+                <div class="header__toggle">
+                    <span class="header__toggle-line"></span>
+                    <span class="header__toggle-line"></span>
+                    <span class="header__toggle-line"></span>
+                </div>
+                <div class="header__logo">
+                    <a href="index.html">
+                        <img src="assets/images/iconcaracteristic/logo-light.png" alt="Logo DOMABLY" class="header__logo--light">
+                        <img src="assets/images/iconcaracteristic/logo-dark.png" alt="Logo DOMABLY" class="header__logo--dark">
+                        <h1 class="header__title sr-only">DOMABLY</h1>
+                    </a>
+                </div>
+                <div class="header__actions">
+                    <a href="#" id="header-login-button" class="header__action-button header__action-button--login">Iniciar Sesión</a>
+                    <a href="register.html" id="header-register-button" class="header__action-button header__action-button--register">Registrar</a>
+                    <a href="profile.html" id="header-profile-link" class="header__action-button header__action-button--profile is-hidden">
+                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 8px;">
+                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="12" cy="7" r="4"></circle>
+                        </svg>
+                        Mi Perfil
+                    </a>
+                </div>
+            </div>
+            <hr class="header__divider">
+            <ul class="header__nav">
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=terrenos">Terrenos</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=casas">Casas</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=departamentos">Departamentos</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=desarrollos">Desarrollos</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Benito Juárez">Cancún</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Tulum">Tulum</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Lázaro Cárdenas">Lázaro Cárdenas</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Playa del Carmen">Playa del Carmen</a></li>
+            </ul>
+            <hr class="header__divider">
+            <nav class="mobile-nav">
+                <ul class="mobile-nav__list">
+                    <li class="mobile-nav__header">
+                        <span class="mobile-nav__title">Tu propiedad ideal</span>
+                        <span class="mobile-nav__close-button">✕</span>
+                    </li>
+                    <div class="mobile-nav__btn" id="mobile-login-button-wrapper">
+                        <a href="#" id="mobile-login-button" class="mobile-nav__auth-link" role="button">
+                            <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4zm-6 4c.22-.72 2.31-1.25 6-1.25s5.78.53 6 1.25z"/>
+                            </svg>
+                            <span class="mobile-nav__auth-text">Log in / Register</span>
+                        </a>
+                    </div>
+                    <div class="mobile-nav__profile-section is-hidden" id="mobile-profile-section">
+                        <a href="#" id="profile-button" class="mobile-nav__auth-link">
+                            <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                                <circle cx="12" cy="7" r="4"></circle>
+                            </svg>
+                            <span class="mobile-nav__auth-text">Mi Perfil</span>
+                            <svg id="profile-arrow" class="mobile-nav__arrow-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </a>
+                        <div id="profile-dropdown" class="mobile-nav__dropdown-menu" style="display: none;">
+                            <a href="#" class="mobile-nav__dropdown-link" data-auth-action="logout">Cerrar Sesión</a>
+                        </div>
+                    </div>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="index.html"><img src="assets/images/iconcaracteristic/home-icon.png" alt="Inicio Icon" class="mobile-nav__icon">Inicio</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="properties.html"><img src="assets/images/iconcaracteristic/properties-icon.png" alt="Propiedades Icon" class="mobile-nav__icon">Propiedades</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="contact.php"><img src="assets/images/iconcaracteristic/contact-icon.png" alt="Contacto Icon" class="mobile-nav__icon">Contacto</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="about.php"><img src="assets/images/iconcaracteristic/about-icon.png" alt="Sobre Nosotros Icon" class="mobile-nav__icon">Sobre Nosotros</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="join.php"><img src="assets/images/iconcaracteristic/join-icon.png" alt="Únete a Nosotros Icon" class="mobile-nav__icon">Únete a Nosotros</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="admin/index.php"><img src="assets/images/iconcaracteristic/account-icon.png" alt="Mi Cuenta Icon" class="mobile-nav__icon">Mi Cuenta</a></li>
+                </ul>
+            </nav>
+        </div>
+        <div class="mobile-nav__overlay"></div>
+        <div id="login-modal" class="auth-modal" aria-hidden="true">
+            <div class="auth-modal__overlay" id="login-modal-overlay"></div>
+            <div class="auth-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="login-modal-title">
+                <button type="button" class="auth-modal__close" id="login-modal-close" aria-label="Cerrar">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <div class="auth-modal__header">
+                    <h2 id="login-modal-title">Bienvenido de vuelta</h2>
+                    <p>Ingresa tus credenciales para continuar explorando oportunidades inmobiliarias.</p>
+                </div>
+                <form id="login-form" class="auth-modal__form" novalidate>
+                    <div class="auth-modal__form-group">
+                        <label for="login-email">Correo electrónico</label>
+                        <input type="email" id="login-email" name="email" placeholder="nombre@dominio.com" required>
+                    </div>
+                    <div class="auth-modal__form-group">
+                        <label for="login-password">Contraseña</label>
+                        <div class="auth-modal__password-wrapper">
+                            <input type="password" id="login-password" name="password" placeholder="Ingresa tu contraseña" required minlength="6">
+                            <button type="button" class="auth-modal__toggle-password" aria-label="Mostrar u ocultar contraseña">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+                                    <circle cx="12" cy="12" r="3"></circle>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="auth-modal__form-row">
+                        <label class="auth-modal__checkbox">
+                            <input type="checkbox" id="remember-me" name="remember">
+                            <span>Recordarme</span>
+                        </label>
+                        <a href="forgot-password.html" class="auth-modal__link">¿Olvidaste tu contraseña?</a>
+                    </div>
+                    <p class="auth-modal__error" id="login-error" role="alert" aria-live="polite"></p>
+                    <button type="submit" class="auth-modal__submit">Iniciar sesión</button>
+                </form>
+                <div class="auth-modal__footer">
+                    <p>¿Aún no tienes cuenta? <a href="register.html" class="auth-modal__link">Crea una ahora</a></p>
+                    <div class="auth-modal__secure">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M4 9V5a4 4 0 0 1 4-4h0a4 4 0 0 1 4 4v4"></path>
+                            <rect x="2" y="9" width="20" height="13" rx="2" ry="2"></rect>
+                            <path d="M12 14v3"></path>
+                        </svg>
+                        <span>Protegemos tus datos con cifrado de grado bancario.</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main class="register">
+        <div class="register__layout container">
+            <section class="register__promo" aria-labelledby="register-title">
+                <span class="register__badge">Únete hoy</span>
+                <h2 id="register-title">Crea una cuenta y acelera tu próxima inversión inmobiliaria</h2>
+                <p>Accede a listados exclusivos, recibe asesoría personalizada y administra tus oportunidades desde un único panel inteligente.</p>
+                <ul class="register__benefits">
+                    <li>
+                        <span class="register__benefit-icon" aria-hidden="true">🔒</span>
+                        Seguridad de nivel bancario para tus datos.
+                    </li>
+                    <li>
+                        <span class="register__benefit-icon" aria-hidden="true">⚡</span>
+                        Alertas inteligentes basadas en tus preferencias.
+                    </li>
+                    <li>
+                        <span class="register__benefit-icon" aria-hidden="true">🤝</span>
+                        Equipo de expertos que te acompaña paso a paso.
+                    </li>
+                </ul>
+                <div class="register__testimonial">
+                    <blockquote>
+                        “Domably transformó la forma en que invertimos. Todo el proceso es transparente, rápido y muy humano.”
+                    </blockquote>
+                    <cite>— Mariana López, Inversionista</cite>
+                </div>
+            </section>
+
+            <section class="register__form-card" aria-label="Formulario de registro">
+                <div class="register-form__header">
+                    <h3>Completa tu perfil</h3>
+                    <p>Solo necesitas unos segundos para comenzar. Te enviaremos un correo de confirmación.</p>
+                    <div class="register-form__progress" aria-hidden="true">
+                        <div class="register-form__progress-step is-active">Datos personales</div>
+                        <div class="register-form__progress-step">Seguridad</div>
+                        <div class="register-form__progress-step">Confirmación</div>
+                    </div>
+                </div>
+                <form id="register-form" class="register-form" novalidate>
+                    <div class="register-form__group">
+                        <label for="register-name">Nombre completo*</label>
+                        <input type="text" id="register-name" name="name" placeholder="Ej. Ana Martínez" autocomplete="name" required>
+                        <p class="register-form__feedback" data-feedback-for="register-name"></p>
+                    </div>
+                    <div class="register-form__group">
+                        <label for="register-email">Correo electrónico*</label>
+                        <input type="email" id="register-email" name="email" placeholder="tuemail@dominio.com" autocomplete="email" required>
+                        <p class="register-form__feedback" data-feedback-for="register-email"></p>
+                    </div>
+                    <div class="register-form__group register-form__group--split">
+                        <div>
+                            <label for="register-phone">Teléfono</label>
+                            <input type="tel" id="register-phone" name="phone" placeholder="10 dígitos" autocomplete="tel">
+                            <p class="register-form__feedback" data-feedback-for="register-phone"></p>
+                        </div>
+                        <div>
+                            <label for="register-birthdate">Fecha de nacimiento</label>
+                            <input type="date" id="register-birthdate" name="birth_date" autocomplete="bday">
+                            <p class="register-form__feedback" data-feedback-for="register-birthdate"></p>
+                        </div>
+                    </div>
+                    <div class="register-form__group register-form__group--password">
+                        <label for="register-password">Contraseña*</label>
+                        <div class="register-form__password-wrapper">
+                            <input type="password" id="register-password" name="password" placeholder="Mínimo 8 caracteres" autocomplete="new-password" required>
+                            <button type="button" class="register-form__toggle" data-toggle="register-password" aria-label="Mostrar u ocultar contraseña"></button>
+                        </div>
+                        <p class="register-form__feedback" data-feedback-for="register-password"></p>
+                        <div class="register-form__strength" id="password-strength" aria-live="polite">Seguridad de la contraseña: <strong>Débil</strong></div>
+                        <ul class="register-form__password-rules">
+                            <li data-rule="length">Al menos 8 caracteres</li>
+                            <li data-rule="number">Incluye un número</li>
+                            <li data-rule="uppercase">Incluye una letra mayúscula</li>
+                        </ul>
+                    </div>
+                    <div class="register-form__group">
+                        <label for="register-password-confirm">Confirmar contraseña*</label>
+                        <div class="register-form__password-wrapper">
+                            <input type="password" id="register-password-confirm" name="passwordConfirm" placeholder="Repite la contraseña" autocomplete="new-password" required>
+                            <button type="button" class="register-form__toggle" data-toggle="register-password-confirm" aria-label="Mostrar u ocultar contraseña"></button>
+                        </div>
+                        <p class="register-form__feedback" data-feedback-for="register-password-confirm"></p>
+                    </div>
+                    <div class="register-form__group register-form__group--checkbox">
+                        <label class="register-form__checkbox">
+                            <input type="checkbox" id="register-terms" required>
+                            <span>Acepto los <a href="#">términos y condiciones</a> y autorizo el tratamiento de mis datos.</span>
+                        </label>
+                        <p class="register-form__feedback" data-feedback-for="register-terms"></p>
+                    </div>
+                    <p class="register-form__message" id="register-form-message" role="alert" aria-live="polite"></p>
+                    <button type="submit" class="register-form__submit" id="register-submit">
+                        <span class="register-form__submit-text">Crear cuenta</span>
+                        <span class="register-form__spinner" aria-hidden="true"></span>
+                    </button>
+                    <p class="register-form__hint">¿Ya tienes cuenta? <a href="#" class="register-form__login-link" id="register-login-link">Inicia sesión aquí</a></p>
+                </form>
+            </section>
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container">
+            <div class="site-footer__grid">
+                <div class="site-footer__column">
+                    <h3 class="site-footer__logo">DOMABLY</h3>
+                    <p>Encuentra la propiedad de tus sueños. Te acompañamos en cada paso del camino.</p>
+                </div>
+
+                <div class="site-footer__column">
+                    <h4>Explora</h4>
+                    <ul>
+                        <li><a href="properties.html?category=terrenos">Terrenos</a></li>
+                        <li><a href="properties.html?category=casas">Casas</a></li>
+                        <li><a href="properties.html?category=departamentos">Departamentos</a></li>
+                        <li><a href="properties.html?category=desarrollos">Desarrollos</a></li>
+                        <li><a href="contact.php">Contacto</a></li>
+                    </ul>
+                </div>
+
+                <div class="site-footer__column">
+                    <h4>Contáctanos</h4>
+                    <p><i class="icon-phone"></i> (52) 999-763-2818</p>
+                    <p><i class="icon-email"></i> <a href="mailto:info@cedralsales.com">info@cedralsales.com</a></p>
+                    <p><i class="icon-location"></i> Cancún, Quintana Roo, México</p>
+                </div>
+
+                <div class="site-footer__column">
+                    <h4>Síguenos</h4>
+                    <div class="site-footer__socials">
+                        <a href="#" class="site-footer__social-link" target="_blank"><img src="assets/images/iconcaracteristic/facebook-icon.png" alt="Facebook"></a>
+                        <a href="#" class="site-footer__social-link" target="_blank"><img src="assets/images/iconcaracteristic/instagram-icon.png" alt="Instagram"></a>
+                        <a href="#" class="site-footer__social-link" target="_blank"><img src="assets/images/iconcaracteristic/twitter-icon.png" alt="Twitter"></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="site-footer__bottom">
+            <p>&copy; <span id="year">2024</span> DOMABLY. Todos los derechos reservados.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+    <script src="assets/js/register.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated register.html page that reuses the global header/login modal and presents a modern two-column onboarding layout
- extend the shared stylesheet with responsive styles for the new registration experience, including animations, progress states and visual feedback
- implement register.js to validate fields, guide the user through password strength, and submit the form to the /api/auth/register backend endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d19c4fede48320b727f5a7c6db3f82