### PR TITLE
Simplify register header

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -211,6 +211,28 @@ body:not(.home){
     transition: color 0.3s ease; /* Transición suave para el color */
 }
 
+.header__back-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    color: #fff;
+    border-radius: 50%;
+    transition: color 0.3s ease, background-color 0.3s ease;
+}
+
+.header__back-link svg {
+    width: 24px;
+    height: 24px;
+}
+
+.header__back-link:hover,
+.header__back-link:focus {
+    color: #0f96da;
+    background-color: #ffffff1a;
+}
+
 
 .header--scrolled .header__toggle {
     color: #2c3e50; /* Negro al deslizar en index */
@@ -218,6 +240,18 @@ body:not(.home){
 
 body:not(.home) .header__toggle {
     color: #2c3e50; /* Negro en otras páginas */
+}
+
+.header--scrolled .header__back-link,
+body:not(.home) .header__back-link {
+    color: #2c3e50;
+}
+
+.header--scrolled .header__back-link:hover,
+.header--scrolled .header__back-link:focus,
+body:not(.home) .header__back-link:hover,
+body:not(.home) .header__back-link:focus {
+    background-color: #2c3e500f;
 }
 
 .mobile-nav__close-button {
@@ -314,11 +348,12 @@ body:not(.home) .header__nav-item a {
         padding-left: 0;
     }
 
-    .header__toggle, .header__logo {
+    .header__toggle, .header__logo, .header__back-link {
         margin-left: 0; /* Sin margen izquierdo */
     }
 
-    .header__toggle {
+    .header__toggle,
+    .header__back-link {
         margin-left: 50px; /* Mantener margen izquierdo */
     }
 

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -12,11 +12,12 @@
     <header>
         <div class="container">
             <div class="header__top">
-                <div class="header__toggle">
-                    <span class="header__toggle-line"></span>
-                    <span class="header__toggle-line"></span>
-                    <span class="header__toggle-line"></span>
-                </div>
+                <a href="index.html" class="header__back-link" aria-label="Regresar al inicio">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="15 18 9 12 15 6"></polyline>
+                        <path d="M20 12H9"></path>
+                    </svg>
+                </a>
                 <div class="header__logo">
                     <a href="index.html">
                         <img src="assets/images/iconcaracteristic/logo-light.png" alt="Logo DOMABLY" class="header__logo--light">
@@ -26,7 +27,6 @@
                 </div>
                 <div class="header__actions">
                     <a href="#" id="header-login-button" class="header__action-button header__action-button--login">Iniciar Sesión</a>
-                    <a href="register.html" id="header-register-button" class="header__action-button header__action-button--register">Registrar</a>
                     <a href="profile.html" id="header-profile-link" class="header__action-button header__action-button--profile is-hidden">
                         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 8px;">
                             <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
@@ -36,57 +36,7 @@
                     </a>
                 </div>
             </div>
-            <hr class="header__divider">
-            <ul class="header__nav">
-                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=terrenos">Terrenos</a></li>
-                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=casas">Casas</a></li>
-                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=departamentos">Departamentos</a></li>
-                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=desarrollos">Desarrollos</a></li>
-                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Benito Juárez">Cancún</a></li>
-                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Tulum">Tulum</a></li>
-                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Lázaro Cárdenas">Lázaro Cárdenas</a></li>
-                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Playa del Carmen">Playa del Carmen</a></li>
-            </ul>
-            <hr class="header__divider">
-            <nav class="mobile-nav">
-                <ul class="mobile-nav__list">
-                    <li class="mobile-nav__header">
-                        <span class="mobile-nav__title">Tu propiedad ideal</span>
-                        <span class="mobile-nav__close-button">✕</span>
-                    </li>
-                    <div class="mobile-nav__btn" id="mobile-login-button-wrapper">
-                        <a href="#" id="mobile-login-button" class="mobile-nav__auth-link" role="button">
-                            <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4zm-6 4c.22-.72 2.31-1.25 6-1.25s5.78.53 6 1.25z"/>
-                            </svg>
-                            <span class="mobile-nav__auth-text">Log in / Register</span>
-                        </a>
-                    </div>
-                    <div class="mobile-nav__profile-section is-hidden" id="mobile-profile-section">
-                        <a href="#" id="profile-button" class="mobile-nav__auth-link">
-                            <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
-                                <circle cx="12" cy="7" r="4"></circle>
-                            </svg>
-                            <span class="mobile-nav__auth-text">Mi Perfil</span>
-                            <svg id="profile-arrow" class="mobile-nav__arrow-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <polyline points="6 9 12 15 18 9"></polyline>
-                            </svg>
-                        </a>
-                        <div id="profile-dropdown" class="mobile-nav__dropdown-menu" style="display: none;">
-                            <a href="#" class="mobile-nav__dropdown-link" data-auth-action="logout">Cerrar Sesión</a>
-                        </div>
-                    </div>
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="index.html"><img src="assets/images/iconcaracteristic/home-icon.png" alt="Inicio Icon" class="mobile-nav__icon">Inicio</a></li>
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="properties.html"><img src="assets/images/iconcaracteristic/properties-icon.png" alt="Propiedades Icon" class="mobile-nav__icon">Propiedades</a></li>
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="contact.php"><img src="assets/images/iconcaracteristic/contact-icon.png" alt="Contacto Icon" class="mobile-nav__icon">Contacto</a></li>
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="about.php"><img src="assets/images/iconcaracteristic/about-icon.png" alt="Sobre Nosotros Icon" class="mobile-nav__icon">Sobre Nosotros</a></li>
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="join.php"><img src="assets/images/iconcaracteristic/join-icon.png" alt="Únete a Nosotros Icon" class="mobile-nav__icon">Únete a Nosotros</a></li>
-                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="admin/index.php"><img src="assets/images/iconcaracteristic/account-icon.png" alt="Mi Cuenta Icon" class="mobile-nav__icon">Mi Cuenta</a></li>
-                </ul>
-            </nav>
         </div>
-        <div class="mobile-nav__overlay"></div>
         <div id="login-modal" class="auth-modal" aria-hidden="true">
             <div class="auth-modal__overlay" id="login-modal-overlay"></div>
             <div class="auth-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="login-modal-title">


### PR DESCRIPTION
## Summary
- replace the register page header with a compact layout that only keeps the top bar
- add a back arrow that links to the home page in place of the hamburger menu
- update shared styles to support the new back button appearance and behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1a636bcf88320a91aa5a31094c795