### PR TITLE
feat: add dynamic registration page

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5451,3 +5451,572 @@ body.auth-modal-open {
         width: 100%;
     }
 }
+/* ================================================= */
+/* === PÁGINA DE REGISTRO === */
+/* ================================================= */
+body.register-page {
+    background: linear-gradient(180deg, #f5f7fb 0%, #ffffff 60%);
+}
+
+body.register-page header {
+    backdrop-filter: blur(6px);
+}
+
+body.register-page .header__action-button.is-active {
+    background: linear-gradient(90deg, #1d4ed8, #2563eb);
+    color: #fff;
+    box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
+}
+
+body.register-page .header__action-button.is-active:hover {
+    transform: translateY(-1px);
+}
+
+.register {
+    position: relative;
+    padding-bottom: 120px;
+}
+
+.register-hero {
+    position: relative;
+    padding: 160px 0 100px;
+    overflow: hidden;
+}
+
+.register-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.15), transparent 55%),
+                radial-gradient(circle at bottom right, rgba(14, 116, 144, 0.12), transparent 50%);
+    opacity: 0.85;
+}
+
+.register-hero__background {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, #0f172a, #1d4ed8);
+    opacity: 0.15;
+    z-index: 0;
+}
+
+.register__grid {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 70px;
+    align-items: center;
+}
+
+.register__intro {
+    color: #0f172a;
+    animation: fadeIn 0.8s ease-out;
+}
+
+.register__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: rgba(37, 99, 235, 0.12);
+    color: #1d4ed8;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+}
+
+.register__intro h1 {
+    margin-top: 20px;
+    font-family: 'DM Serif Display', serif;
+    font-size: clamp(2.3rem, 3vw, 3.4rem);
+    line-height: 1.1;
+    color: #0b1f44;
+}
+
+.register__intro p {
+    margin-top: 20px;
+    font-size: 1.05rem;
+    color: #334155;
+    max-width: 520px;
+}
+
+.register-benefits {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 24px;
+    margin-top: 35px;
+    list-style: none;
+}
+
+.register-benefits li {
+    background: #ffffffcc;
+    border-radius: 18px;
+    padding: 24px 26px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(4px);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.register-benefits h3 {
+    font-size: 1.05rem;
+    color: #0f172a;
+    margin-bottom: 10px;
+}
+
+.register-benefits p {
+    color: #475569;
+    font-size: 0.95rem;
+}
+
+.register__card {
+    background: #fff;
+    border-radius: 28px;
+    padding: 38px 42px;
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.15);
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    position: relative;
+    overflow: hidden;
+}
+
+.register__card::after {
+    content: "";
+    position: absolute;
+    top: -60px;
+    right: -60px;
+    width: 160px;
+    height: 160px;
+    background: radial-gradient(circle, rgba(59, 130, 246, 0.18), transparent 65%);
+}
+
+.register__card-header {
+    margin-bottom: 28px;
+}
+
+.register__card-header h2 {
+    font-size: 1.75rem;
+    color: #0f172a;
+    margin-bottom: 8px;
+}
+
+.register__card-header p {
+    color: #475569;
+    font-size: 0.98rem;
+}
+
+.register-progress {
+    margin-top: 26px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.register-progress__steps {
+    display: flex;
+    justify-content: space-between;
+    gap: 18px;
+}
+
+.register-progress__step {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: #94a3b8;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.register-progress__label {
+    font-size: 0.9rem;
+}
+
+.register-progress__circle {
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 2px solid rgba(148, 163, 184, 0.4);
+    font-size: 0.9rem;
+    font-weight: 600;
+    transition: all 0.3s ease;
+}
+
+.register-progress__step.is-complete {
+    color: #1d4ed8;
+}
+
+.register-progress__step.is-complete .register-progress__circle {
+    background: linear-gradient(135deg, #1d4ed8, #2563eb);
+    border-color: transparent;
+    color: #fff;
+    box-shadow: 0 10px 20px rgba(37, 99, 235, 0.35);
+}
+
+.register-progress__bar {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    background: rgba(148, 163, 184, 0.2);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.register-progress__bar-fill {
+    position: absolute;
+    inset: 0;
+    width: 0;
+    background: linear-gradient(90deg, #1d4ed8, #38bdf8);
+    transition: width 0.4s ease;
+}
+
+.register-form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.register-form__row {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.register-form__group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    position: relative;
+}
+
+.register-form__group label {
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.register-form__group input[type="text"],
+.register-form__group input[type="email"],
+.register-form__group input[type="tel"],
+.register-form__group input[type="date"],
+.register-form__group input[type="password"] {
+    width: 100%;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding: 14px 16px;
+    font-size: 1rem;
+    transition: border 0.25s ease, box-shadow 0.25s ease;
+    background: rgba(248, 250, 252, 0.85);
+}
+
+.register-form__group input:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+}
+
+.register-form__group.has-error input {
+    border-color: #ef4444;
+    background: rgba(254, 226, 226, 0.5);
+}
+
+.register-form__group.is-valid input {
+    border-color: #22c55e;
+    background: rgba(209, 250, 229, 0.45);
+}
+
+.register-form__helper {
+    font-size: 0.85rem;
+    color: #64748b;
+}
+
+.register-form__error {
+    font-size: 0.85rem;
+    color: #ef4444;
+    min-height: 18px;
+}
+
+.register-form__password-wrapper {
+    display: flex;
+    align-items: center;
+    position: relative;
+}
+
+.register-form__password-wrapper input {
+    padding-right: 46px;
+}
+
+.register-form__toggle {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 8px;
+    transition: background 0.2s ease;
+    color: #64748b;
+}
+
+.register-form__toggle:hover,
+.register-form__toggle.is-active {
+    background: rgba(37, 99, 235, 0.1);
+    color: #1d4ed8;
+}
+
+.register-form__password-meter {
+    height: 4px;
+    background: rgba(148, 163, 184, 0.25);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.register-form__password-meter-bar {
+    width: 0;
+    height: 100%;
+    border-radius: 999px;
+    transition: width 0.35s ease;
+    background: #f87171;
+}
+
+.register-form__options {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 10px;
+}
+
+.register-form__checkbox {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    color: #475569;
+    font-size: 0.9rem;
+}
+
+.register-form__checkbox input {
+    margin-top: 3px;
+}
+
+.register-form__checkbox a {
+    color: #1d4ed8;
+    font-weight: 600;
+}
+
+.register-form__feedback {
+    font-size: 0.95rem;
+    min-height: 20px;
+    margin-top: 6px;
+}
+
+.register-form__feedback.is-error {
+    color: #dc2626;
+}
+
+.register-form__feedback.is-success {
+    color: #16a34a;
+}
+
+.register-form__submit {
+    margin-top: 8px;
+    border: none;
+    border-radius: 999px;
+    padding: 14px 26px;
+    background: linear-gradient(135deg, #1d4ed8, #2563eb);
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 20px 40px rgba(37, 99, 235, 0.35);
+}
+
+.register-form__submit:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+}
+
+.register-form__submit:not(:disabled):hover {
+    transform: translateY(-2px);
+    box-shadow: 0 25px 40px rgba(37, 99, 235, 0.45);
+}
+
+.register-form__spinner {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    border-top-color: #fff;
+    animation: spin 0.8s linear infinite;
+    display: none;
+}
+
+.register-form__submit.is-loading .register-form__spinner {
+    display: inline-block;
+}
+
+.register-form__submit.is-loading .register-form__submit-text {
+    opacity: 0.8;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.register-form__footer {
+    margin-top: 6px;
+    font-size: 0.95rem;
+    color: #475569;
+}
+
+.register-form__footer a {
+    color: #1d4ed8;
+    font-weight: 600;
+}
+
+.register-security {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 24px;
+    padding: 14px 18px;
+    background: rgba(37, 99, 235, 0.08);
+    border-radius: 16px;
+    color: #1d4ed8;
+    font-size: 0.9rem;
+}
+
+.register-insights {
+    padding: 40px 0 0;
+}
+
+.register-insights__grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 30px;
+}
+
+.register-insight {
+    background: #fff;
+    border-radius: 20px;
+    padding: 32px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    text-align: center;
+    transition: transform 0.2s ease;
+}
+
+.register-insight:hover {
+    transform: translateY(-6px);
+}
+
+.register-insight h3 {
+    font-size: 1.4rem;
+    color: #0f172a;
+    margin-bottom: 10px;
+}
+
+.register-insight p {
+    color: #64748b;
+    font-size: 0.95rem;
+}
+
+@media (max-width: 1200px) {
+    .register__grid {
+        gap: 50px;
+    }
+
+    .register__card {
+        padding: 34px 36px;
+    }
+}
+
+@media (max-width: 992px) {
+    .register-hero {
+        padding: 140px 0 80px;
+    }
+
+    .register__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .register__intro {
+        text-align: center;
+    }
+
+    .register__intro p,
+    .register-benefits {
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .register__card {
+        max-width: 580px;
+        margin: 0 auto;
+    }
+
+    .register-benefits {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .register-hero {
+        padding: 120px 0 70px;
+    }
+
+    .register__card {
+        padding: 28px;
+    }
+
+    .register-form__row {
+        grid-template-columns: 1fr;
+    }
+
+    .register-insights__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 600px) {
+    .register-benefits {
+        grid-template-columns: 1fr;
+    }
+
+    .register-insights__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .register__card {
+        padding: 24px 22px;
+    }
+
+    .register-progress__steps {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+@media (max-width: 480px) {
+    .register-hero {
+        padding: 110px 0 60px;
+    }
+
+    .register__badge {
+        font-size: 0.75rem;
+    }
+
+    .register__card-header h2 {
+        font-size: 1.5rem;
+    }
+}
+

--- a/frontend/assets/js/register.js
+++ b/frontend/assets/js/register.js
@@ -1,0 +1,374 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('register-form');
+    if (!form) {
+        return;
+    }
+
+    const DEFAULT_API = 'http://localhost:3000/api';
+
+    const resolveApiBase = () => {
+        const dataAttr = document.body.dataset.apiBase;
+        if (dataAttr) {
+            return dataAttr;
+        }
+        const { hostname, origin } = window.location;
+        if (hostname === 'localhost' || hostname === '127.0.0.1') {
+            return DEFAULT_API;
+        }
+        if (origin && origin !== 'null' && origin !== 'file://') {
+            return `${origin.replace(/\/$/, '')}/api`;
+        }
+        return DEFAULT_API;
+    };
+
+    const API_URL = resolveApiBase();
+    const REGISTER_ENDPOINT = `${API_URL}/auth/register`;
+
+    const submitButton = form.querySelector('.register-form__submit');
+    const submitText = form.querySelector('.register-form__submit-text');
+    const spinner = form.querySelector('.register-form__spinner');
+    const feedback = document.getElementById('register-feedback');
+    const steps = Array.from(document.querySelectorAll('.register-progress__step'));
+    const progressBar = document.querySelector('.register-progress__bar-fill');
+    const strengthBar = document.getElementById('password-strength-bar');
+    const strengthText = document.getElementById('password-strength-text');
+    const passwordInput = document.getElementById('register-password');
+    const confirmPasswordInput = document.getElementById('register-confirm-password');
+    const birthInput = document.getElementById('register-birth');
+    const loginLink = document.getElementById('register-login-link');
+
+    if (birthInput) {
+        const today = new Date();
+        birthInput.max = today.toISOString().split('T')[0];
+    }
+
+    if (loginLink) {
+        loginLink.addEventListener('click', (event) => {
+            event.preventDefault();
+            const loginTrigger = document.getElementById('header-login-button');
+            if (loginTrigger) {
+                loginTrigger.dispatchEvent(new Event('click', { bubbles: true }));
+            }
+        });
+    }
+
+    const toggleButtons = Array.from(document.querySelectorAll('.register-form__toggle'));
+    toggleButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const input = button.previousElementSibling;
+            if (!input) {
+                return;
+            }
+            const isPassword = input.getAttribute('type') === 'password';
+            input.setAttribute('type', isPassword ? 'text' : 'password');
+            button.classList.toggle('is-active', isPassword);
+        });
+    });
+
+    const validators = {
+        name: (value) => {
+            if (!value.trim()) {
+                return 'Ingresa tu nombre completo.';
+            }
+            if (value.trim().length < 3) {
+                return 'El nombre debe tener al menos 3 caracteres.';
+            }
+            return '';
+        },
+        email: (value) => {
+            if (!value.trim()) {
+                return 'El correo electrónico es obligatorio.';
+            }
+            const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            if (!emailRegex.test(value.trim())) {
+                return 'Ingresa un correo electrónico válido.';
+            }
+            return '';
+        },
+        phone: (value) => {
+            if (!value.trim()) {
+                return '';
+            }
+            const digits = value.replace(/\D/g, '');
+            if (digits.length < 10) {
+                return 'Ingresa un teléfono de al menos 10 dígitos.';
+            }
+            return '';
+        },
+        birth_date: (value) => {
+            if (!value) {
+                return '';
+            }
+            const selected = new Date(value);
+            const now = new Date();
+            if (selected > now) {
+                return 'Selecciona una fecha de nacimiento válida.';
+            }
+            const adultDate = new Date(now.getFullYear() - 18, now.getMonth(), now.getDate());
+            if (selected > adultDate) {
+                return 'Debes ser mayor de 18 años para registrarte.';
+            }
+            return '';
+        },
+        password: (value) => {
+            if (!value) {
+                return 'Crea una contraseña para continuar.';
+            }
+            if (value.length < 8) {
+                return 'La contraseña debe tener al menos 8 caracteres.';
+            }
+            const requirements = [/[a-z]/, /[A-Z]/, /\d/, /[^A-Za-z0-9]/];
+            const metRequirements = requirements.filter((regex) => regex.test(value)).length;
+            if (metRequirements < 3) {
+                return 'Combina mayúsculas, minúsculas, números y símbolos.';
+            }
+            return '';
+        },
+        confirm_password: (value) => {
+            if (!value) {
+                return 'Confirma tu contraseña.';
+            }
+            if (value !== (passwordInput ? passwordInput.value : '')) {
+                return 'Las contraseñas no coinciden.';
+            }
+            return '';
+        },
+        terms: (checked) => {
+            if (!checked) {
+                return 'Debes aceptar los términos y condiciones.';
+            }
+            return '';
+        },
+    };
+
+    const fields = Array.from(form.querySelectorAll('input'));
+
+    const getFieldName = (input) => input.getAttribute('name');
+
+    const getGroup = (input) => input.closest('.register-form__group');
+
+    const showError = (input, message) => {
+        const group = getGroup(input);
+        if (!group) {
+            return;
+        }
+        const errorElement = group.querySelector('.register-form__error');
+        if (errorElement) {
+            errorElement.textContent = message;
+        }
+        group.classList.toggle('has-error', !!message);
+        const value = input.type === 'checkbox' ? (input.checked ? 'checked' : '') : input.value;
+        const shouldMarkValid = !message && value.trim() !== '';
+        group.classList.toggle('is-valid', shouldMarkValid);
+    };
+
+    const validateInput = (input, options = { silent: false }) => {
+        const name = getFieldName(input);
+        if (!name || !(name in validators)) {
+            return true;
+        }
+        const value = name === 'terms' ? input.checked : input.value;
+        const message = validators[name](value);
+        if (!options.silent) {
+            showError(input, message);
+        }
+        return !message;
+    };
+
+    const updateStrengthMeter = (value) => {
+        if (!strengthBar || !strengthText) {
+            return;
+        }
+        const requirements = [/[a-z]/, /[A-Z]/, /\d/, /[^A-Za-z0-9]/];
+        let score = 0;
+        if (value.length >= 8) {
+            score += 1;
+        }
+        requirements.forEach((regex) => {
+            if (regex.test(value)) {
+                score += 1;
+            }
+        });
+        const clampedScore = Math.min(score, 4);
+        const percentage = (clampedScore / 4) * 100;
+        strengthBar.style.width = `${percentage}%`;
+        let label = 'Débil';
+        let color = '#f87171';
+        if (clampedScore >= 3) {
+            label = 'Segura';
+            color = '#34d399';
+        } else if (clampedScore === 2) {
+            label = 'Media';
+            color = '#fbbf24';
+        }
+        strengthBar.style.background = color;
+        strengthText.textContent = value ? `Seguridad de contraseña: ${label}` : 'Usa mayúsculas, números y símbolos para una contraseña robusta.';
+    };
+
+    const stepThresholds = [40, 80, 100];
+
+    const updateProgress = () => {
+        const trackedFields = ['name', 'email', 'password', 'confirm_password', 'terms'];
+        const completed = trackedFields.reduce((count, fieldName) => {
+            const input = form.querySelector(`[name="${fieldName}"]`);
+            if (!input) {
+                return count;
+            }
+            return count + (validateInput(input, { silent: true }) ? 1 : 0);
+        }, 0);
+        const total = trackedFields.length;
+        const percent = Math.round((completed / total) * 100);
+        if (progressBar) {
+            progressBar.style.width = `${percent}%`;
+        }
+        steps.forEach((step, index) => {
+            const threshold = stepThresholds[index] ?? 100;
+            const isComplete = percent >= threshold;
+            step.classList.toggle('is-complete', isComplete);
+        });
+    };
+
+    const updateSubmitState = () => {
+        const requiredFields = ['name', 'email', 'password', 'confirm_password', 'terms'];
+        const allValid = requiredFields.every((name) => {
+            const input = form.querySelector(`[name="${name}"]`);
+            return input ? validateInput(input, { silent: true }) : true;
+        });
+        if (submitButton) {
+            submitButton.disabled = !allValid;
+        }
+    };
+
+    fields.forEach((input) => {
+        input.addEventListener('input', () => {
+            if (input === passwordInput) {
+                updateStrengthMeter(input.value);
+                if (confirmPasswordInput && confirmPasswordInput.value) {
+                    validateInput(confirmPasswordInput);
+                }
+            }
+            validateInput(input, { silent: input.type === 'checkbox' });
+            updateProgress();
+            updateSubmitState();
+        });
+        input.addEventListener('blur', () => {
+            validateInput(input);
+            updateProgress();
+            updateSubmitState();
+        });
+    });
+
+    if (passwordInput) {
+        updateStrengthMeter(passwordInput.value);
+    }
+    updateProgress();
+    updateSubmitState();
+
+    let previousSubmitDisabled = false;
+
+    const setLoadingState = (isLoading) => {
+        if (!submitButton) {
+            return;
+        }
+        if (isLoading) {
+            previousSubmitDisabled = submitButton.disabled;
+            submitButton.disabled = true;
+        } else {
+            submitButton.disabled = previousSubmitDisabled;
+            updateSubmitState();
+        }
+        submitButton.classList.toggle('is-loading', isLoading);
+        if (submitText) {
+            submitText.textContent = isLoading ? 'Creando cuenta…' : 'Crear cuenta';
+        }
+        if (spinner) {
+            spinner.style.display = isLoading ? 'inline-block' : 'none';
+        }
+        form.classList.toggle('is-loading', isLoading);
+    };
+
+    const resetForm = () => {
+        form.reset();
+        fields.forEach((input) => {
+            showError(input, '');
+        });
+        updateStrengthMeter('');
+        updateProgress();
+        updateSubmitState();
+    };
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        feedback.textContent = '';
+        feedback.classList.remove('is-error', 'is-success');
+        const requiredInputs = ['name', 'email', 'password', 'confirm_password', 'terms'];
+        let isValid = true;
+        requiredInputs.forEach((name) => {
+            const input = form.querySelector(`[name="${name}"]`);
+            if (input && !validateInput(input)) {
+                isValid = false;
+            }
+        });
+        const optionalInputs = ['phone', 'birth_date'];
+        optionalInputs.forEach((name) => {
+            const input = form.querySelector(`[name="${name}"]`);
+            if (input) {
+                validateInput(input);
+            }
+        });
+        if (!isValid) {
+            feedback.textContent = 'Revisa los campos marcados en rojo para continuar.';
+            feedback.classList.remove('is-success');
+            feedback.classList.add('is-error');
+            return;
+        }
+
+        const payload = {
+            name: form.name.value.trim(),
+            email: form.email.value.trim(),
+            password: form.password.value,
+            phone: form.phone.value.trim() || null,
+            birth_date: form.birth_date.value || null,
+        };
+
+        try {
+            setLoadingState(true);
+            const response = await fetch(REGISTER_ENDPOINT, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+            });
+
+            const data = await response.json().catch(() => ({ message: 'No se pudo interpretar la respuesta del servidor.' }));
+
+            if (!response.ok) {
+                const message = data?.message || 'No pudimos crear tu cuenta. Inténtalo nuevamente.';
+                feedback.textContent = message;
+                feedback.classList.remove('is-success');
+                feedback.classList.add('is-error');
+                return;
+            }
+
+            feedback.textContent = data?.message || '¡Tu cuenta ha sido creada exitosamente!';
+            feedback.classList.remove('is-error');
+            feedback.classList.add('is-success');
+            resetForm();
+
+            setTimeout(() => {
+                const loginTrigger = document.getElementById('header-login-button');
+                if (loginTrigger) {
+                    loginTrigger.dispatchEvent(new Event('click', { bubbles: true }));
+                }
+            }, 1800);
+        } catch (error) {
+            console.error('Error al registrar:', error);
+            feedback.textContent = 'Ocurrió un error inesperado. Verifica tu conexión e inténtalo nuevamente.';
+            feedback.classList.remove('is-success');
+            feedback.classList.add('is-error');
+        } finally {
+            setLoadingState(false);
+        }
+    });
+});

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Crear cuenta - DOMABLY</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="register-page">
+    <header>
+        <div class="container">
+            <div class="header__top">
+                <div class="header__toggle">
+                    <span class="header__toggle-line"></span>
+                    <span class="header__toggle-line"></span>
+                    <span class="header__toggle-line"></span>
+                </div>
+                <div class="header__logo">
+                    <a href="index.html">
+                        <img src="assets/images/iconcaracteristic/logo-light.png" alt="Logo DOMABLY" class="header__logo--light">
+                        <img src="assets/images/iconcaracteristic/logo-dark.png" alt="Logo DOMABLY" class="header__logo--dark">
+                        <h1 class="header__title sr-only">DOMABLY</h1>
+                    </a>
+                </div>
+                <div class="header__actions">
+                    <a href="#" id="header-login-button" class="header__action-button header__action-button--login">Iniciar Sesión</a>
+                    <a href="register.html" id="header-register-button" class="header__action-button header__action-button--register is-active">Registrar</a>
+                    <a href="profile.html" id="header-profile-link" class="header__action-button header__action-button--profile is-hidden">
+                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 8px;">
+                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="12" cy="7" r="4"></circle>
+                        </svg>
+                        Mi Perfil
+                    </a>
+                </div>
+            </div>
+            <hr class="header__divider">
+            <ul class="header__nav">
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=terrenos">Terrenos</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=casas">Casas</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=departamentos">Departamentos</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?category=desarrollos">Desarrollos</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Benito Juárez">Cancún</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Tulum">Tulum</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Lázaro Cárdenas">Lázaro Cárdenas</a></li>
+                <li class="header__nav-item"><a class="header__nav-link" href="properties.html?location=Playa del Carmen">Playa del Carmen</a></li>
+            </ul>
+            <hr class="header__divider">
+            <nav class="mobile-nav">
+                <ul class="mobile-nav__list">
+                    <li class="mobile-nav__header">
+                        <span class="mobile-nav__title">Tu propiedad ideal</span>
+                        <span class="mobile-nav__close-button">✕</span>
+                    </li>
+                    <div class="mobile-nav__btn" id="mobile-login-button-wrapper">
+                        <a href="#" id="mobile-login-button" class="mobile-nav__auth-link" role="button">
+                            <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4zm-6 4c.22-.72 2.31-1.25 6-1.25s5.78.53 6 1.25z"/>
+                            </svg>
+                            <span class="mobile-nav__auth-text">Log in / Register</span>
+                        </a>
+                    </div>
+                    <div class="mobile-nav__profile-section is-hidden" id="mobile-profile-section">
+                        <a href="#" id="profile-button" class="mobile-nav__auth-link">
+                            <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                                <circle cx="12" cy="7" r="4"></circle>
+                            </svg>
+                            <span class="mobile-nav__auth-text">Mi Perfil</span>
+                            <svg id="profile-arrow" class="mobile-nav__arrow-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </a>
+                        <div id="profile-dropdown" class="mobile-nav__dropdown-menu" style="display: none;">
+                            <a href="#" class="mobile-nav__dropdown-link" data-auth-action="logout">Cerrar Sesión</a>
+                        </div>
+                    </div>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="index.html"><img src="assets/images/iconcaracteristic/home-icon.png" alt="Inicio Icon" class="mobile-nav__icon">Inicio</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="properties.html"><img src="assets/images/iconcaracteristic/properties-icon.png" alt="Propiedades Icon" class="mobile-nav__icon">Propiedades</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="contact.php"><img src="assets/images/iconcaracteristic/contact-icon.png" alt="Contacto Icon" class="mobile-nav__icon">Contacto</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="about.php"><img src="assets/images/iconcaracteristic/about-icon.png" alt="Sobre Nosotros Icon" class="mobile-nav__icon">Sobre Nosotros</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="join.php"><img src="assets/images/iconcaracteristic/join-icon.png" alt="Únete a Nosotros Icon" class="mobile-nav__icon">Únete a Nosotros</a></li>
+                    <li class="mobile-nav__item"><a class="mobile-nav__link" href="admin/index.php"><img src="assets/images/iconcaracteristic/account-icon.png" alt="Mi Cuenta Icon" class="mobile-nav__icon">Mi Cuenta</a></li>
+                </ul>
+            </nav>
+        </div>
+        <div class="mobile-nav__overlay"></div>
+        <div id="login-modal" class="auth-modal" aria-hidden="true">
+            <div class="auth-modal__overlay" id="login-modal-overlay"></div>
+            <div class="auth-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="login-modal-title">
+                <button type="button" class="auth-modal__close" id="login-modal-close" aria-label="Cerrar">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <div class="auth-modal__header">
+                    <h2 id="login-modal-title">Bienvenido de vuelta</h2>
+                    <p>Ingresa tus credenciales para continuar explorando oportunidades inmobiliarias.</p>
+                </div>
+                <form id="login-form" class="auth-modal__form" novalidate>
+                    <div class="auth-modal__form-group">
+                        <label for="login-email">Correo electrónico</label>
+                        <input type="email" id="login-email" name="email" placeholder="nombre@dominio.com" required>
+                    </div>
+                    <div class="auth-modal__form-group">
+                        <label for="login-password">Contraseña</label>
+                        <div class="auth-modal__password-wrapper">
+                            <input type="password" id="login-password" name="password" placeholder="Ingresa tu contraseña" required minlength="6">
+                            <button type="button" class="auth-modal__toggle-password" aria-label="Mostrar u ocultar contraseña">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+                                    <circle cx="12" cy="12" r="3"></circle>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="auth-modal__form-row">
+                        <label class="auth-modal__checkbox">
+                            <input type="checkbox" id="remember-me" name="remember">
+                            <span>Recordarme</span>
+                        </label>
+                        <a href="forgot-password.html" class="auth-modal__link">¿Olvidaste tu contraseña?</a>
+                    </div>
+                    <p class="auth-modal__error" id="login-error" role="alert" aria-live="polite"></p>
+                    <button type="submit" class="auth-modal__submit">Iniciar sesión</button>
+                </form>
+                <div class="auth-modal__footer">
+                    <p>¿Aún no tienes cuenta? <a href="register.html" class="auth-modal__link">Crea una ahora</a></p>
+                    <div class="auth-modal__secure">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M4 9V5a4 4 0 0 1 4-4h0a4 4 0 0 1 4 4v4"></path>
+                            <rect x="2" y="9" width="20" height="13" rx="2" ry="2"></rect>
+                            <path d="M12 14v3"></path>
+                        </svg>
+                        <span>Protegemos tus datos con cifrado de grado bancario.</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main class="register">
+        <section class="register-hero" aria-labelledby="register-title">
+            <div class="register-hero__background" aria-hidden="true"></div>
+            <div class="container register__grid">
+                <div class="register__intro">
+                    <span class="register__badge">Cuenta gratuita</span>
+                    <h1 id="register-title">Potencia tus inversiones con una cuenta DOMABLY</h1>
+                    <p>Accede a listados exclusivos, guarda tus propiedades favoritas y recibe alertas personalizadas según tus intereses. Diseñamos una experiencia ágil y segura para inversionistas, asesores y compradores.</p>
+                    <ul class="register-benefits" aria-label="Beneficios de crear una cuenta">
+                        <li>
+                            <h3>Alertas inteligentes</h3>
+                            <p>Te notificamos nuevas oportunidades basadas en tus filtros.</p>
+                        </li>
+                        <li>
+                            <h3>Panel personalizado</h3>
+                            <p>Administra seguimientos, visitas y documentos desde un solo lugar.</p>
+                        </li>
+                        <li>
+                            <h3>Soporte dedicado</h3>
+                            <p>Contamos con especialistas inmobiliarios listos para ayudarte.</p>
+                        </li>
+                    </ul>
+                </div>
+                <div class="register__card" aria-live="polite">
+                    <div class="register__card-header">
+                        <h2>Crea tu perfil en minutos</h2>
+                        <p>Completa la información y comienza a explorar propiedades diseñadas para ti.</p>
+                        <div class="register-progress" aria-hidden="true">
+                            <div class="register-progress__steps">
+                                <div class="register-progress__step" data-step="1">
+                                    <span class="register-progress__circle">1</span>
+                                    <span class="register-progress__label">Datos personales</span>
+                                </div>
+                                <div class="register-progress__step" data-step="2">
+                                    <span class="register-progress__circle">2</span>
+                                    <span class="register-progress__label">Acceso seguro</span>
+                                </div>
+                                <div class="register-progress__step" data-step="3">
+                                    <span class="register-progress__circle">3</span>
+                                    <span class="register-progress__label">Listo</span>
+                                </div>
+                            </div>
+                            <div class="register-progress__bar">
+                                <div class="register-progress__bar-fill" style="width: 0%;"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <form id="register-form" class="register-form" novalidate>
+                        <div class="register-form__group" data-field="name">
+                            <label for="register-name">Nombre completo</label>
+                            <input type="text" id="register-name" name="name" placeholder="Como aparece en tu identificación" autocomplete="name" required>
+                            <p class="register-form__helper">Usa nombres y apellidos sin abreviaturas.</p>
+                            <p class="register-form__error" aria-live="polite"></p>
+                        </div>
+                        <div class="register-form__group" data-field="email">
+                            <label for="register-email">Correo electrónico</label>
+                            <input type="email" id="register-email" name="email" placeholder="nombre@dominio.com" autocomplete="email" required>
+                            <p class="register-form__error" aria-live="polite"></p>
+                        </div>
+                        <div class="register-form__row">
+                            <div class="register-form__group" data-field="phone">
+                                <label for="register-phone">Teléfono móvil</label>
+                                <input type="tel" id="register-phone" name="phone" placeholder="10 dígitos" autocomplete="tel">
+                                <p class="register-form__helper">Te contactaremos sólo para agendar visitas o confirmar citas.</p>
+                                <p class="register-form__error" aria-live="polite"></p>
+                            </div>
+                            <div class="register-form__group" data-field="birth_date">
+                                <label for="register-birth">Fecha de nacimiento</label>
+                                <input type="date" id="register-birth" name="birth_date" max="">
+                                <p class="register-form__helper">Personalizamos recomendaciones según tu perfil.</p>
+                                <p class="register-form__error" aria-live="polite"></p>
+                            </div>
+                        </div>
+                        <div class="register-form__group" data-field="password">
+                            <label for="register-password">Crea una contraseña</label>
+                            <div class="register-form__password-wrapper">
+                                <input type="password" id="register-password" name="password" placeholder="Mínimo 8 caracteres" autocomplete="new-password" required>
+                                <button class="register-form__toggle" type="button" aria-label="Mostrar u ocultar contraseña">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+                                        <circle cx="12" cy="12" r="3"></circle>
+                                    </svg>
+                                </button>
+                            </div>
+                            <div class="register-form__password-meter" aria-hidden="true">
+                                <div class="register-form__password-meter-bar" id="password-strength-bar"></div>
+                            </div>
+                            <p class="register-form__helper" id="password-strength-text">Usa mayúsculas, números y símbolos para una contraseña robusta.</p>
+                            <p class="register-form__error" aria-live="polite"></p>
+                        </div>
+                        <div class="register-form__group" data-field="confirm_password">
+                            <label for="register-confirm-password">Confirma tu contraseña</label>
+                            <div class="register-form__password-wrapper">
+                                <input type="password" id="register-confirm-password" name="confirm_password" placeholder="Repite la contraseña" autocomplete="new-password" required>
+                                <button class="register-form__toggle" type="button" aria-label="Mostrar u ocultar contraseña">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+                                        <circle cx="12" cy="12" r="3"></circle>
+                                    </svg>
+                                </button>
+                            </div>
+                            <p class="register-form__error" aria-live="polite"></p>
+                        </div>
+                        <div class="register-form__options">
+                            <label class="register-form__checkbox">
+                                <input type="checkbox" id="register-terms" name="terms" required>
+                                <span>Acepto los <a href="#" target="_blank" rel="noopener">términos y condiciones</a> y la <a href="#" target="_blank" rel="noopener">política de privacidad</a>.</span>
+                            </label>
+                            <label class="register-form__checkbox">
+                                <input type="checkbox" id="register-news" name="newsletter">
+                                <span>Quiero recibir novedades y oportunidades exclusivas.</span>
+                            </label>
+                        </div>
+                        <p class="register-form__feedback" id="register-feedback" role="alert" aria-live="polite"></p>
+                        <button type="submit" class="register-form__submit" disabled>
+                            <span class="register-form__submit-text">Crear cuenta</span>
+                            <span class="register-form__spinner" aria-hidden="true"></span>
+                        </button>
+                        <p class="register-form__footer">¿Ya tienes una cuenta? <a href="#" id="register-login-link">Inicia sesión</a></p>
+                    </form>
+                    <div class="register-security" aria-hidden="true">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+                            <polyline points="9 12 12 15 15 9"></polyline>
+                        </svg>
+                        <p>Tus datos se almacenan con cifrado AES-256 y auditorías constantes.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="register-insights" aria-label="Estadísticas y testimonios">
+            <div class="container register-insights__grid">
+                <div class="register-insight">
+                    <h3>+4,500 usuarios</h3>
+                    <p>Profesionales inmobiliarios y compradores activos que confían en DOMABLY.</p>
+                </div>
+                <div class="register-insight">
+                    <h3>Respuesta en 24h</h3>
+                    <p>Nuestro equipo valida tus solicitudes y te acompaña durante todo el proceso.</p>
+                </div>
+                <div class="register-insight">
+                    <h3>Experiencia 360°</h3>
+                    <p>Visitas virtuales, firmas digitales y asesoría financiera desde la plataforma.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container">
+            <div class="site-footer__grid">
+                <div class="site-footer__column">
+                    <h3 class="site-footer__logo">DOMABLY</h3>
+                    <p>Encuentra la propiedad de tus sueños. Te acompañamos en cada paso del camino.</p>
+                </div>
+                <div class="site-footer__column">
+                    <h4>Explora</h4>
+                    <ul>
+                        <li><a href="properties.html?category=terrenos">Terrenos</a></li>
+                        <li><a href="properties.html?category=casas">Casas</a></li>
+                        <li><a href="properties.html?category=departamentos">Departamentos</a></li>
+                        <li><a href="properties.html?category=desarrollos">Desarrollos</a></li>
+                        <li><a href="contact.php">Contacto</a></li>
+                    </ul>
+                </div>
+                <div class="site-footer__column">
+                    <h4>Contáctanos</h4>
+                    <p><i class="icon-phone"></i> (52) 999-763-2818</p>
+                    <p><i class="icon-email"></i> <a href="mailto:info@cedralsales.com">info@cedralsales.com</a></p>
+                    <p><i class="icon-location"></i> Cancún, Quintana Roo, México</p>
+                </div>
+                <div class="site-footer__column">
+                    <h4>Síguenos</h4>
+                    <div class="site-footer__socials">
+                        <a href="#" class="site-footer__social-link" target="_blank"><img src="assets/images/iconcaracteristic/facebook-icon.png" alt="Facebook"></a>
+                        <a href="#" class="site-footer__social-link" target="_blank"><img src="assets/images/iconcaracteristic/instagram-icon.png" alt="Instagram"></a>
+                        <a href="#" class="site-footer__social-link" target="_blank"><img src="assets/images/iconcaracteristic/twitter-icon.png" alt="Twitter"></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="site-footer__bottom">
+            <p>&copy; <span id="year"></span> DOMABLY. Todos los derechos reservados.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+    <script src="assets/js/register.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated register.html page with hero messaging, benefits, and the full registration form alongside the existing header/footer
- extend styles.css with a polished responsive design for the registration experience, including progress indicators, layout cards, and adaptive breakpoints
- implement register.js to validate inputs, show password strength, and submit the form to the `/api/auth/register` endpoint while providing inline feedback

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d20fc332408320b06d49c25853a0a9