### PR TITLE
Improve register page layout and support content

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5558,6 +5558,33 @@ body.register-page .header__action-button.is-active:hover {
     box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
     backdrop-filter: blur(4px);
     border: 1px solid rgba(148, 163, 184, 0.2);
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.register-benefits li:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 28px 55px rgba(15, 23, 42, 0.14);
+}
+
+.register-benefits__icon {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 46px;
+    height: 46px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(14, 116, 144, 0.08));
+    color: #1d4ed8;
+}
+
+.register-benefits__content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .register-benefits h3 {
@@ -5676,7 +5703,36 @@ body.register-page .header__action-button.is-active:hover {
 .register-form {
     display: flex;
     flex-direction: column;
+    gap: 22px;
+}
+
+.register-form__section {
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    border-radius: 18px;
+    padding: 24px 26px;
+    display: flex;
+    flex-direction: column;
     gap: 18px;
+    background: rgba(248, 250, 252, 0.75);
+    margin: 0;
+    position: relative;
+}
+
+.register-form__section legend {
+    font-weight: 700;
+    color: #1d4ed8;
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 4px;
+    padding: 0 12px;
+    background: #fff;
+    border-radius: 999px;
+    align-self: flex-start;
+}
+
+.register-form__section legend + * {
+    margin-top: 2px;
 }
 
 .register-form__row {
@@ -5883,6 +5939,71 @@ body.register-page .header__action-button.is-active:hover {
     font-weight: 600;
 }
 
+.register-support {
+    margin-top: 28px;
+    display: flex;
+    gap: 18px;
+    padding: 22px 24px;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(30, 64, 175, 0.08), rgba(37, 99, 235, 0.15));
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    align-items: flex-start;
+}
+
+.register-support__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 52px;
+    height: 52px;
+    border-radius: 16px;
+    background: #1d4ed8;
+    color: #fff;
+    box-shadow: 0 15px 35px rgba(37, 99, 235, 0.25);
+}
+
+.register-support__content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.register-support__content h3 {
+    font-size: 1.05rem;
+    color: #0f172a;
+}
+
+.register-support__content p {
+    color: #475569;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.register-support__link {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: #fff;
+    border: 1px solid rgba(37, 99, 235, 0.4);
+    color: #1d4ed8;
+    font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.register-support__link::after {
+    content: '→';
+    font-size: 1.1rem;
+}
+
+.register-support__link:hover {
+    background: #1d4ed8;
+    color: #fff;
+    transform: translateY(-1px);
+}
+
 .register-security {
     display: flex;
     align-items: center;
@@ -5967,6 +6088,10 @@ body.register-page .header__action-button.is-active:hover {
     .register-benefits {
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
+
+    .register-support {
+        flex-direction: column;
+    }
 }
 
 @media (max-width: 768px) {
@@ -5976,6 +6101,10 @@ body.register-page .header__action-button.is-active:hover {
 
     .register__card {
         padding: 28px;
+    }
+
+    .register-form__section {
+        padding: 20px;
     }
 
     .register-form__row {
@@ -6000,6 +6129,10 @@ body.register-page .header__action-button.is-active:hover {
         padding: 24px 22px;
     }
 
+    .register-form__section {
+        padding: 18px;
+    }
+
     .register-progress__steps {
         flex-direction: column;
         align-items: flex-start;
@@ -6017,6 +6150,11 @@ body.register-page .header__action-button.is-active:hover {
 
     .register__card-header h2 {
         font-size: 1.5rem;
+    }
+
+    .register-support__icon {
+        width: 46px;
+        height: 46px;
     }
 }
 

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -147,16 +147,43 @@
                     <p>Accede a listados exclusivos, guarda tus propiedades favoritas y recibe alertas personalizadas según tus intereses. Diseñamos una experiencia ágil y segura para inversionistas, asesores y compradores.</p>
                     <ul class="register-benefits" aria-label="Beneficios de crear una cuenta">
                         <li>
-                            <h3>Alertas inteligentes</h3>
-                            <p>Te notificamos nuevas oportunidades basadas en tus filtros.</p>
+                            <span class="register-benefits__icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M9 18l6-6-6-6" />
+                                    <path d="M5 12h14" />
+                                </svg>
+                            </span>
+                            <div class="register-benefits__content">
+                                <h3>Alertas inteligentes</h3>
+                                <p>Te notificamos nuevas oportunidades basadas en tus filtros.</p>
+                            </div>
                         </li>
                         <li>
-                            <h3>Panel personalizado</h3>
-                            <p>Administra seguimientos, visitas y documentos desde un solo lugar.</p>
+                            <span class="register-benefits__icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <rect x="3" y="3" width="18" height="14" rx="2" ry="2" />
+                                    <path d="M7 21h10" />
+                                    <path d="M12 17v4" />
+                                </svg>
+                            </span>
+                            <div class="register-benefits__content">
+                                <h3>Panel personalizado</h3>
+                                <p>Administra seguimientos, visitas y documentos desde un solo lugar.</p>
+                            </div>
                         </li>
                         <li>
-                            <h3>Soporte dedicado</h3>
-                            <p>Contamos con especialistas inmobiliarios listos para ayudarte.</p>
+                            <span class="register-benefits__icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M18 20a6 6 0 0 0-12 0" />
+                                    <circle cx="12" cy="10" r="4" />
+                                    <path d="M19 8v6" />
+                                    <path d="M22 11h-6" />
+                                </svg>
+                            </span>
+                            <div class="register-benefits__content">
+                                <h3>Soporte dedicado</h3>
+                                <p>Contamos con especialistas inmobiliarios listos para ayudarte.</p>
+                            </div>
                         </li>
                     </ul>
                 </div>
@@ -185,61 +212,69 @@
                         </div>
                     </div>
                     <form id="register-form" class="register-form" novalidate>
-                        <div class="register-form__group" data-field="name">
-                            <label for="register-name">Nombre completo</label>
-                            <input type="text" id="register-name" name="name" placeholder="Como aparece en tu identificación" autocomplete="name" required>
-                            <p class="register-form__helper">Usa nombres y apellidos sin abreviaturas.</p>
-                            <p class="register-form__error" aria-live="polite"></p>
-                        </div>
-                        <div class="register-form__group" data-field="email">
-                            <label for="register-email">Correo electrónico</label>
-                            <input type="email" id="register-email" name="email" placeholder="nombre@dominio.com" autocomplete="email" required>
-                            <p class="register-form__error" aria-live="polite"></p>
-                        </div>
-                        <div class="register-form__row">
-                            <div class="register-form__group" data-field="phone">
-                                <label for="register-phone">Teléfono móvil</label>
-                                <input type="tel" id="register-phone" name="phone" placeholder="10 dígitos" autocomplete="tel">
-                                <p class="register-form__helper">Te contactaremos sólo para agendar visitas o confirmar citas.</p>
+                        <fieldset class="register-form__section" aria-describedby="register-section-details">
+                            <legend id="register-section-details">Datos personales</legend>
+                            <div class="register-form__group" data-field="name">
+                                <label for="register-name">Nombre completo</label>
+                                <input type="text" id="register-name" name="name" placeholder="Como aparece en tu identificación" autocomplete="name" required>
+                                <p class="register-form__helper">Usa nombres y apellidos sin abreviaturas.</p>
                                 <p class="register-form__error" aria-live="polite"></p>
                             </div>
-                            <div class="register-form__group" data-field="birth_date">
-                                <label for="register-birth">Fecha de nacimiento</label>
-                                <input type="date" id="register-birth" name="birth_date" max="">
-                                <p class="register-form__helper">Personalizamos recomendaciones según tu perfil.</p>
+                            <div class="register-form__group" data-field="email">
+                                <label for="register-email">Correo electrónico</label>
+                                <input type="email" id="register-email" name="email" placeholder="nombre@dominio.com" autocomplete="email" required>
                                 <p class="register-form__error" aria-live="polite"></p>
                             </div>
-                        </div>
-                        <div class="register-form__group" data-field="password">
-                            <label for="register-password">Crea una contraseña</label>
-                            <div class="register-form__password-wrapper">
-                                <input type="password" id="register-password" name="password" placeholder="Mínimo 8 caracteres" autocomplete="new-password" required>
-                                <button class="register-form__toggle" type="button" aria-label="Mostrar u ocultar contraseña">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
-                                        <circle cx="12" cy="12" r="3"></circle>
-                                    </svg>
-                                </button>
+                            <div class="register-form__row">
+                                <div class="register-form__group" data-field="phone">
+                                    <label for="register-phone">Teléfono móvil</label>
+                                    <input type="tel" id="register-phone" name="phone" placeholder="10 dígitos" autocomplete="tel">
+                                    <p class="register-form__helper">Te contactaremos sólo para agendar visitas o confirmar citas.</p>
+                                    <p class="register-form__error" aria-live="polite"></p>
+                                </div>
+                                <div class="register-form__group" data-field="birth_date">
+                                    <label for="register-birth">Fecha de nacimiento</label>
+                                    <input type="date" id="register-birth" name="birth_date" max="">
+                                    <p class="register-form__helper">Personalizamos recomendaciones según tu perfil.</p>
+                                    <p class="register-form__error" aria-live="polite"></p>
+                                </div>
                             </div>
-                            <div class="register-form__password-meter" aria-hidden="true">
-                                <div class="register-form__password-meter-bar" id="password-strength-bar"></div>
+                        </fieldset>
+
+                        <fieldset class="register-form__section" aria-describedby="register-section-access">
+                            <legend id="register-section-access">Acceso seguro</legend>
+                            <div class="register-form__group" data-field="password">
+                                <label for="register-password">Crea una contraseña</label>
+                                <div class="register-form__password-wrapper">
+                                    <input type="password" id="register-password" name="password" placeholder="Mínimo 8 caracteres" autocomplete="new-password" required>
+                                    <button class="register-form__toggle" type="button" aria-label="Mostrar u ocultar contraseña">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+                                            <circle cx="12" cy="12" r="3"></circle>
+                                        </svg>
+                                    </button>
+                                </div>
+                                <div class="register-form__password-meter" aria-hidden="true">
+                                    <div class="register-form__password-meter-bar" id="password-strength-bar"></div>
+                                </div>
+                                <p class="register-form__helper" id="password-strength-text">Usa mayúsculas, números y símbolos para una contraseña robusta.</p>
+                                <p class="register-form__error" aria-live="polite"></p>
                             </div>
-                            <p class="register-form__helper" id="password-strength-text">Usa mayúsculas, números y símbolos para una contraseña robusta.</p>
-                            <p class="register-form__error" aria-live="polite"></p>
-                        </div>
-                        <div class="register-form__group" data-field="confirm_password">
-                            <label for="register-confirm-password">Confirma tu contraseña</label>
-                            <div class="register-form__password-wrapper">
-                                <input type="password" id="register-confirm-password" name="confirm_password" placeholder="Repite la contraseña" autocomplete="new-password" required>
-                                <button class="register-form__toggle" type="button" aria-label="Mostrar u ocultar contraseña">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
-                                        <circle cx="12" cy="12" r="3"></circle>
-                                    </svg>
-                                </button>
+                            <div class="register-form__group" data-field="confirm_password">
+                                <label for="register-confirm-password">Confirma tu contraseña</label>
+                                <div class="register-form__password-wrapper">
+                                    <input type="password" id="register-confirm-password" name="confirm_password" placeholder="Repite la contraseña" autocomplete="new-password" required>
+                                    <button class="register-form__toggle" type="button" aria-label="Mostrar u ocultar contraseña">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+                                            <circle cx="12" cy="12" r="3"></circle>
+                                        </svg>
+                                    </button>
+                                </div>
+                                <p class="register-form__error" aria-live="polite"></p>
                             </div>
-                            <p class="register-form__error" aria-live="polite"></p>
-                        </div>
+                        </fieldset>
+
                         <div class="register-form__options">
                             <label class="register-form__checkbox">
                                 <input type="checkbox" id="register-terms" name="terms" required>
@@ -263,6 +298,20 @@
                             <polyline points="9 12 12 15 15 9"></polyline>
                         </svg>
                         <p>Tus datos se almacenan con cifrado AES-256 y auditorías constantes.</p>
+                    </div>
+                    <div class="register-support" role="complementary" aria-label="Soporte personalizado">
+                        <div class="register-support__icon" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M22 16.92V19a2 2 0 0 1-2.18 2 19.86 19.86 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.86 19.86 0 0 1 2 4.18 2 2 0 0 1 4 2h2.09a2 2 0 0 1 2 1.72 12.65 12.65 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L7.91 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.65 12.65 0 0 0 2.81.7 2 2 0 0 1 1.72 2.03z"></path>
+                                <path d="M14 4l6 6" />
+                                <path d="M16 2l6 6" />
+                            </svg>
+                        </div>
+                        <div class="register-support__content">
+                            <h3>¿Necesitas ayuda durante el registro?</h3>
+                            <p>Un asesor de DOMABLY puede guiarte para completar tu perfil e identificar las mejores oportunidades.</p>
+                            <a class="register-support__link" href="contact.php">Agendar asesoría gratuita</a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- enhance the register hero benefits with visual icons and hover states
- reorganize the registration form into clearly labeled sections with helper copy and add a support CTA block
- extend styling to support the new layout, including fieldset design, support card, and responsive adjustments

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d212e520408320979dfa4ff6bad554