### PR TITLE
Ajusta la introducción del registro en escritorio

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5479,7 +5479,7 @@ body.register-page .header__action-button.is-active:hover {
 
 .register-hero {
     position: relative;
-    padding: 160px 0 100px;
+    padding: 130px 0 90px;
     overflow: hidden;
 }
 
@@ -5506,7 +5506,7 @@ body.register-page .header__action-button.is-active:hover {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 70px;
-    align-items: center;
+    align-items: flex-start;
 }
 
 .register__intro {
@@ -6061,9 +6061,19 @@ body.register-page .header__action-button.is-active:hover {
     }
 }
 
+@media (min-width: 1200px) {
+    .register-hero {
+        padding: 120px 0 90px;
+    }
+
+    .register__intro {
+        max-width: 540px;
+    }
+}
+
 @media (max-width: 992px) {
     .register-hero {
-        padding: 140px 0 80px;
+        padding: 120px 0 80px;
     }
 
     .register__grid {


### PR DESCRIPTION
## Summary
- reduce el padding superior del hero de registro para acercar el contenido al encabezado en pantallas grandes
- alinea el grid del hero al inicio y ajusta el ancho máximo de la introducción para mejorar su posición en escritorio
- armoniza el padding responsivo del hero en tablets para mantener la consistencia visual

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d216c770e0832089b52e453b998883