### PR TITLE
Make register intro section sticky

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5512,6 +5512,9 @@ body.register-page .header__action-button.is-active:hover {
 .register__intro {
     color: #0f172a;
     animation: fadeIn 0.8s ease-out;
+    position: sticky;
+    top: 120px;
+    align-self: flex-start;
 }
 
 .register__badge {
@@ -6082,6 +6085,7 @@ body.register-page .header__action-button.is-active:hover {
 
     .register__intro {
         text-align: center;
+        position: static;
     }
 
     .register__intro p,


### PR DESCRIPTION
## Summary
- keep the register intro column visible by making it sticky with an offset from the top
- reset the intro section positioning on tablet and smaller screens so it behaves normally in the single-column layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2dde6f78483208c2c1eef86b55c3f