### PR TITLE
Fix register layout for medium-width screens

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5502,6 +5502,7 @@ body.register-page {
     height: fit-content;
     color: #0f172a;
     animation: fadeIn 0.8s ease-out;
+    max-width: 600px;
 }
 
 .register__badge {
@@ -6048,6 +6049,42 @@ body.register-page {
 
     .register__card {
         padding: 34px 36px;
+    }
+}
+
+@media (max-width: 1100px) {
+    .register__grid {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 60px;
+    }
+
+    .register__intro {
+        position: relative;
+        top: 0;
+        margin: 0 auto;
+        text-align: center;
+        max-width: 640px;
+    }
+
+    .register__intro p,
+    .register-benefits {
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .register-benefits {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .register__card {
+        max-width: 640px;
+        margin: 0 auto;
+    }
+
+    .register-support {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
     }
 }
 


### PR DESCRIPTION
## Summary
- limit the width of the register intro column to prevent stretching on medium screens
- add a responsive breakpoint to stack the intro and form with centered support content on tablet-sized displays

## Testing
- not run (styles only)


------
https://chatgpt.com/codex/tasks/task_e_68d36677dea88320965409ad6d5a9feb