### PR TITLE
Integrate backend-authenticated login and user profile API

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -3,6 +3,7 @@
 const db = require('../config/db');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const { formatUserForResponse } = require('../utils/userFormatter');
 
 // Función para registrar un nuevo usuario
 exports.register = async (req, res) => {
@@ -83,8 +84,11 @@ exports.login = async (req, res) => {
       { expiresIn: '1h' }, // El token expira en 1 hora
       (error, token) => {
         if (error) throw error;
-        // 4. Enviar el token al cliente
-        res.json({ token });
+        // 4. Enviar el token y los datos básicos del usuario al cliente
+        res.json({
+          token,
+          user: formatUserForResponse(req, user)
+        });
       }
     );
 

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,0 +1,151 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('../config/db');
+const { formatUserForResponse } = require('../utils/userFormatter');
+
+const deleteFileIfExists = async (filePath) => {
+  if (!filePath) {
+    return;
+  }
+
+  const absolutePath = path.join(process.cwd(), filePath);
+  try {
+    await fs.promises.unlink(absolutePath);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.error('No se pudo eliminar el archivo antiguo:', error.message);
+    }
+  }
+};
+
+exports.getProfile = async (req, res) => {
+  const userId = req.user?.id;
+
+  if (!userId) {
+    return res.status(401).json({ message: 'Usuario no autenticado.' });
+  }
+
+  let connection;
+
+  try {
+    connection = await db.getConnection();
+    const [rows] = await connection.query(
+      `SELECT id, name, email, phone, birth_date, role, profile_image, bio, company, website, created_at, updated_at
+       FROM users
+       WHERE id = ?
+       LIMIT 1`,
+      [userId]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'No se encontró el usuario solicitado.' });
+    }
+
+    const user = rows[0];
+    res.json({ user: formatUserForResponse(req, user) });
+  } catch (error) {
+    console.error('Error al obtener el perfil del usuario:', error);
+    res.status(500).json({ message: 'Ocurrió un error al obtener tu información.' });
+  } finally {
+    if (connection) {
+      connection.release();
+    }
+  }
+};
+
+exports.updateProfile = async (req, res) => {
+  const userId = req.user?.id;
+
+  if (!userId) {
+    return res.status(401).json({ message: 'Usuario no autenticado.' });
+  }
+
+  const {
+    name,
+    phone,
+    birthDate,
+    bio,
+    company,
+    website,
+  } = req.body;
+
+  const hasFile = Boolean(req.file);
+  const normalizedFilePath = hasFile ? req.file.path.replace(/\\/g, '/') : null;
+
+  let connection;
+
+  try {
+    connection = await db.getConnection();
+
+    const [existingRows] = await connection.query(
+      'SELECT profile_image FROM users WHERE id = ? LIMIT 1',
+      [userId]
+    );
+
+    if (existingRows.length === 0) {
+      return res.status(404).json({ message: 'No se encontró el usuario solicitado.' });
+    }
+
+    const updates = [];
+    const values = [];
+
+    const pushUpdate = (column, value) => {
+      if (typeof value === 'undefined') {
+        return;
+      }
+      updates.push(`${column} = ?`);
+      values.push(value === '' ? null : value);
+    };
+
+    pushUpdate('name', name?.trim());
+    pushUpdate('phone', phone?.trim());
+    pushUpdate('birth_date', birthDate || null);
+    pushUpdate('bio', bio?.trim());
+    pushUpdate('company', company?.trim());
+    pushUpdate('website', website?.trim());
+
+    if (hasFile) {
+      updates.push('profile_image = ?');
+      values.push(normalizedFilePath);
+    }
+
+    if (updates.length === 0) {
+      return res.status(400).json({ message: 'No se detectaron cambios para actualizar.' });
+    }
+
+    updates.push('updated_at = NOW()');
+    values.push(userId);
+
+    const sql = `UPDATE users SET ${updates.join(', ')} WHERE id = ?`;
+    await connection.query(sql, values);
+
+    const [updatedRows] = await connection.query(
+      `SELECT id, name, email, phone, birth_date, role, profile_image, bio, company, website, created_at, updated_at
+       FROM users
+       WHERE id = ?
+       LIMIT 1`,
+      [userId]
+    );
+
+    const updatedUser = updatedRows[0];
+
+    if (hasFile) {
+      const previousImage = existingRows[0]?.profile_image;
+      if (previousImage && previousImage !== normalizedFilePath) {
+        await deleteFileIfExists(previousImage);
+      }
+    }
+
+    res.json({
+      message: 'Perfil actualizado correctamente.',
+      user: formatUserForResponse(req, updatedUser),
+    });
+  } catch (error) {
+    console.error('Error al actualizar el perfil del usuario:', error);
+    res.status(500).json({ message: 'Ocurrió un error al actualizar tu perfil.' });
+  } finally {
+    if (connection) {
+      connection.release();
+    }
+  }
+};

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -4,7 +4,14 @@ const jwt = require('jsonwebtoken');
 
 module.exports = function(req, res, next) {
   // Obtener el token del encabezado de la petición
-  const token = req.header('x-auth-token');
+  let token = req.header('x-auth-token');
+
+  if (!token && req.headers.authorization) {
+    const [scheme, credentials] = req.headers.authorization.split(' ');
+    if (scheme && scheme.toLowerCase() === 'bearer' && credentials) {
+      token = credentials.trim();
+    }
+  }
 
   // Verificar si no hay token
   if (!token) {

--- a/backend/middleware/userUploadMiddleware.js
+++ b/backend/middleware/userUploadMiddleware.js
@@ -1,0 +1,47 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const ensureDirectoryExists = (directoryPath) => {
+  fs.mkdirSync(directoryPath, { recursive: true });
+};
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    const userId = req.user?.id || 'anonymous';
+    const uploadPath = path.join('public', 'uploads', 'users', String(userId));
+
+    try {
+      ensureDirectoryExists(uploadPath);
+      cb(null, uploadPath);
+    } catch (error) {
+      cb(error);
+    }
+  },
+  filename: (req, file, cb) => {
+    const timestamp = Date.now();
+    const randomSuffix = Math.round(Math.random() * 1e9);
+    const extension = path.extname(file.originalname) || '.png';
+    cb(null, `avatar-${timestamp}-${randomSuffix}${extension}`);
+  },
+});
+
+const fileFilter = (req, file, cb) => {
+  if (file.mimetype && file.mimetype.startsWith('image/')) {
+    cb(null, true);
+    return;
+  }
+  cb(new Error('Solo se permiten archivos de imagen.'));
+};
+
+const uploadUserAvatar = multer({
+  storage,
+  fileFilter,
+  limits: {
+    fileSize: 3 * 1024 * 1024, // 3 MB
+  },
+});
+
+module.exports = {
+  uploadUserAvatar,
+};

--- a/backend/public/uploads/.gitignore
+++ b/backend/public/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const userController = require('../controllers/userController');
+const authMiddleware = require('../middleware/authMiddleware');
+const { uploadUserAvatar } = require('../middleware/userUploadMiddleware');
+
+router.get('/me', authMiddleware, userController.getProfile);
+router.put('/me', authMiddleware, uploadUserAvatar.single('profile_image'), userController.updateProfile);
+router.patch('/me', authMiddleware, uploadUserAvatar.single('profile_image'), userController.updateProfile);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -21,6 +21,7 @@ const sellerRoutes = require('./routes/sellerRoutes');
 const adminRoutes = require('./routes/adminRoutes');
 const heroRoutes = require('./routes/heroRoutes');
 const newsRoutes = require('./routes/newsRoutes');
+const userRoutes = require('./routes/userRoutes');
 
 app.use('/api/properties', propertiesRoutes);
 app.use('/api/auth', authRoutes);
@@ -28,6 +29,7 @@ app.use('/api/seller', sellerRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api', heroRoutes);
 app.use('/api', newsRoutes);
+app.use('/api/users', userRoutes);
 
 // Una ruta de prueba
 app.get('/api', (req, res) => {

--- a/backend/utils/userFormatter.js
+++ b/backend/utils/userFormatter.js
@@ -1,0 +1,34 @@
+const path = require('path');
+
+const buildPublicUrl = (req, value) => {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.replace(/\\/g, '/');
+  const prefixed = normalized.startsWith('public/')
+    ? normalized
+    : path.posix.join('public', normalized);
+  const publicPath = prefixed.replace(/^public\//, 'public/');
+
+  return `${req.protocol}://${req.get('host')}/${publicPath}`;
+};
+
+const formatUserForResponse = (req, dbUser = {}) => ({
+  id: dbUser.id,
+  name: dbUser.name,
+  email: dbUser.email,
+  role: dbUser.role,
+  phone: dbUser.phone,
+  birthDate: dbUser.birth_date,
+  company: dbUser.company,
+  website: dbUser.website,
+  bio: dbUser.bio,
+  profileImageUrl: buildPublicUrl(req, dbUser.profile_image),
+  createdAt: dbUser.created_at,
+  updatedAt: dbUser.updated_at,
+});
+
+module.exports = {
+  formatUserForResponse,
+};

--- a/cedralsales.sql
+++ b/cedralsales.sql
@@ -33,6 +33,41 @@ CREATE TABLE `admins` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `users`
+--
+
+DROP TABLE IF EXISTS `users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `users` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `email` varchar(255) NOT NULL,
+  `password` varchar(255) NOT NULL,
+  `phone` varchar(20) DEFAULT NULL,
+  `birth_date` date DEFAULT NULL,
+  `role` enum('user','admin','agent') DEFAULT 'user',
+  `profile_image` varchar(255) DEFAULT NULL,
+  `bio` text,
+  `company` varchar(255) DEFAULT NULL,
+  `website` varchar(255) DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `users_email_unique` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `users`
+--
+
+LOCK TABLES `users` WRITE;
+/*!40000 ALTER TABLE `users` DISABLE KEYS */;
+/*!40000 ALTER TABLE `users` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Dumping data for table `admins`
 --
 

--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -5027,6 +5027,47 @@ body.lightbox-active {
     white-space: nowrap; /* Evita que el texto se parta en dos líneas */
 }
 
+.header__action-button--profile {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background-color: rgba(0, 0, 0, 0.45);
+    border-color: transparent;
+    padding: 8px 14px 8px 10px;
+}
+
+.header__profile-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #4c6ef5, #15aabf);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 13px;
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.header__profile-avatar.has-photo {
+    background-size: cover;
+    background-position: center;
+    color: transparent;
+}
+
+.header__action-button--profile:hover .header__profile-avatar {
+    transform: scale(1.05);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.header__profile-name {
+    font-weight: 600;
+    text-transform: none;
+}
+
 .header__action-button--register {
     background-color: #fff;
     color: #2c3e50;
@@ -5050,6 +5091,7 @@ body.lightbox-active {
 .header--scrolled .header__action-button--profile {
     background-color: #000000;
     color: #fff;
+    border-color: #000;
 }
 
 /* Estilos para las otras páginas */
@@ -5061,6 +5103,12 @@ body:not(.home) .header__action-button {
 body:not(.home) .header__action-button--register {
     background-color: #2c3e50;
     color: #fff;
+}
+
+body:not(.home) .header__action-button--profile {
+    background-color: #2c3e50;
+    color: #fff;
+    border-color: #2c3e50;
 }
 
 @media (max-width: 768px) {
@@ -5086,6 +5134,61 @@ body:not(.home) .header__action-button--register {
     text-decoration: none;
     font-weight: 500;
     transition: background-color 0.3s ease;
+}
+
+.mobile-nav__auth-link--profile {
+    justify-content: flex-start;
+    gap: 12px;
+    background-color: rgba(0, 0, 0, 0.08);
+    color: #1f2933;
+}
+
+.mobile-nav__profile-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #4c6ef5, #15aabf);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    transition: transform 0.3s ease;
+}
+
+.mobile-nav__profile-avatar.has-photo {
+    background-size: cover;
+    background-position: center;
+    color: transparent;
+}
+
+.mobile-nav__auth-link--profile:hover .mobile-nav__profile-avatar {
+    transform: scale(1.05);
+}
+
+.mobile-nav__profile-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.2;
+}
+
+.mobile-nav__profile-label {
+    font-size: 0.75rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.mobile-nav__profile-name {
+    font-weight: 600;
+    color: #111827;
+}
+
+.mobile-nav__dropdown-link--logout {
+    color: #b91c1c;
 }
 
 .mobile-nav__auth-link:hover {
@@ -5377,6 +5480,11 @@ body:not(.home) .header__action-button--register {
     font-size: 16px;
     cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-modal__submit.is-loading {
+    cursor: wait;
+    opacity: 0.8;
 }
 
 .auth-modal__submit:hover,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,12 +25,9 @@
                 <div class="header__actions">
                     <a href="#" id="header-login-button" class="header__action-button header__action-button--login">Iniciar Sesión</a>
                     <a href="register.html" id="header-register-button" class="header__action-button header__action-button--register">Registrar</a>
-                    <a href="profile.html" id="header-profile-link" class="header__action-button header__action-button--profile is-hidden">
-                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 8px;">
-                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
-                            <circle cx="12" cy="7" r="4"></circle>
-                        </svg>
-                        Mi Perfil
+                    <a href="profile.html" id="header-profile-link" class="header__action-button header__action-button--profile is-hidden" aria-label="Ir a mi perfil">
+                        <span class="header__profile-avatar" id="header-profile-avatar" aria-hidden="true">U</span>
+                        <span class="header__profile-name" id="header-profile-name">Mi perfil</span>
                     </a>
                 </div>
             </div>
@@ -61,18 +58,19 @@
                         </a>
                     </div>
                     <div class="mobile-nav__profile-section is-hidden" id="mobile-profile-section">
-                        <a href="#" id="profile-button" class="mobile-nav__auth-link">
-                            <svg class="mobile-nav__auth-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
-                                <circle cx="12" cy="7" r="4"></circle>
-                            </svg>
-                            <span class="mobile-nav__auth-text">Mi Perfil</span>
+                        <a href="#" id="profile-button" class="mobile-nav__auth-link mobile-nav__auth-link--profile">
+                            <span class="mobile-nav__profile-avatar" id="mobile-profile-avatar" aria-hidden="true">U</span>
+                            <div class="mobile-nav__profile-info">
+                                <span class="mobile-nav__profile-label">Mi cuenta</span>
+                                <span class="mobile-nav__profile-name" id="mobile-profile-name">Invitado</span>
+                            </div>
                             <svg id="profile-arrow" class="mobile-nav__arrow-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <polyline points="6 9 12 15 18 9"></polyline>
                             </svg>
                         </a>
                         <div id="profile-dropdown" class="mobile-nav__dropdown-menu" style="display: none;">
-                            <a href="#" class="mobile-nav__dropdown-link" data-auth-action="logout">Cerrar Sesión</a>
+                            <a href="profile.html" class="mobile-nav__dropdown-link" data-auth-action="profile">Panel de usuario</a>
+                            <a href="#" class="mobile-nav__dropdown-link mobile-nav__dropdown-link--logout" data-auth-action="logout">Cerrar Sesión</a>
                         </div>
                     </div>
                     <li class="mobile-nav__item"><a class="mobile-nav__link" href="index.html"><img src="assets/images/iconcaracteristic/home-icon.png" alt="Inicio Icon" class="mobile-nav__icon">Inicio</a></li>


### PR DESCRIPTION
## Summary
- wire the front-end login flow to the Node.js authentication endpoints and persist JWT-based sessions, refreshing profile data on load and handling logout across desktop and mobile menus
- add user profile endpoints with avatar upload support plus shared formatting helpers, and expose them from the server alongside stricter auth header handling
- update the database schema and UI styling to accommodate persistent profile metadata, refreshed header/mobile profile affordances, and loading feedback in the login modal

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5b8b6c58c832090b1d485eb1462e9