### PR TITLE
Add Mis propiedades view to profile dashboard

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6282,6 +6282,92 @@ body.profile-page {
     overflow-y: auto; /* Para scroll si el contenido es largo */
 }
 
+.profile__panel {
+    display: none;
+    min-height: 100%;
+}
+
+.profile__panel--active {
+    display: block;
+}
+
+.properties-empty {
+    display: flex;
+    align-items: center;
+    gap: 32px;
+    padding: 36px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(236, 248, 255, 0.9));
+    border: 1px solid rgba(52, 152, 219, 0.15);
+}
+
+.properties-empty__illustration {
+    flex-shrink: 0;
+    width: 120px;
+    height: 120px;
+    border-radius: 24px;
+    background: radial-gradient(circle at 35% 35%, rgba(46, 204, 113, 0.35), transparent 65%),
+                linear-gradient(135deg, rgba(52, 152, 219, 0.15), rgba(41, 128, 185, 0.3));
+    position: relative;
+}
+
+.properties-empty__illustration::after {
+    content: "";
+    position: absolute;
+    inset: 24px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.65);
+    box-shadow: 0 16px 32px rgba(52, 152, 219, 0.15);
+}
+
+.properties-empty__content {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.properties-empty__title {
+    font-size: 24px;
+    font-weight: 700;
+    color: #1f2937;
+    margin: 0;
+}
+
+.properties-empty__description {
+    font-size: 16px;
+    color: #4b5563;
+    margin: 0;
+    max-width: 520px;
+}
+
+.properties-empty__note {
+    font-size: 14px;
+    color: #6b7280;
+    margin: 0;
+}
+
+.properties-tips {
+    padding: 36px 40px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(243, 249, 255, 0.96));
+    border: 1px solid rgba(209, 213, 219, 0.6);
+}
+
+.properties-tips__title {
+    font-size: 20px;
+    font-weight: 700;
+    color: #1f2937;
+    margin: 0 0 18px;
+}
+
+.properties-tips__list {
+    margin: 0;
+    padding-left: 20px;
+    display: grid;
+    gap: 12px;
+    color: #4b5563;
+    font-size: 15px;
+    line-height: 1.6;
+}
+
 /*
 =================================
 DASHBOARD DEL PERFIL

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -20,10 +20,10 @@
             <nav class="sidebar__nav">
                 <ul class="sidebar__menu">
                     <li class="sidebar__menu-item">
-                        <a href="#" class="sidebar__menu-link sidebar__menu-link--active">Inicio</a>
+                        <a href="#" class="sidebar__menu-link sidebar__menu-link--active" data-section="inicio">Inicio</a>
                     </li>
                     <li class="sidebar__menu-item">
-                        <a href="#" class="sidebar__menu-link">Mis propiedades</a>
+                        <a href="#" class="sidebar__menu-link" data-section="propiedades">Mis propiedades</a>
                     </li>
                     <li class="sidebar__menu-item">
                         <a href="#" class="sidebar__menu-link">Leads</a>
@@ -42,6 +42,7 @@
         </aside>
 
         <main class="profile__main-content">
+            <div class="profile__panel profile__panel--active" data-section="inicio">
                 <div class="dashboard__breadcrumb">
                     <span class="breadcrumb__label">Panel</span>
                     <span class="breadcrumb__divider">/</span>
@@ -52,211 +53,272 @@
                     <button class="dashboard__action-btn dashboard__action-btn--primary">Crear nuevo anuncio</button>
                 </div>
 
-            <section class="dashboard__hero card">
-                <div class="dashboard__hero-info">
-                    <p class="dashboard__hero-subtitle">Hola, (Nombre de usuario)</p>
-                    <h1 class="dashboard__hero-title">Tu panel de rendimiento</h1>
-                    <p class="dashboard__hero-description">Monitorea tus publicaciones, leads y métricas clave desde un entorno pensado para profesionales inmobiliarios.</p>
-                    <div class="dashboard__hero-status">
-                        <span class="status-badge status-badge--success">Cuenta verificada</span>
-                        <span class="status-badge status-badge--neutral">Plan Profesional</span>
+                <section class="dashboard__hero card">
+                    <div class="dashboard__hero-info">
+                        <p class="dashboard__hero-subtitle">Hola, (Nombre de usuario)</p>
+                        <h1 class="dashboard__hero-title">Tu panel de rendimiento</h1>
+                        <p class="dashboard__hero-description">Monitorea tus publicaciones, leads y métricas clave desde un entorno pensado para profesionales inmobiliarios.</p>
+                        <div class="dashboard__hero-status">
+                            <span class="status-badge status-badge--success">Cuenta verificada</span>
+                            <span class="status-badge status-badge--neutral">Plan Profesional</span>
+                        </div>
                     </div>
-                </div>
-                <div class="dashboard__hero-stats">
-                    <div class="hero-stat">
-                        <span class="hero-stat__label">Última actualización</span>
-                        <span class="hero-stat__value">Hace 2 horas</span>
+                    <div class="dashboard__hero-stats">
+                        <div class="hero-stat">
+                            <span class="hero-stat__label">Última actualización</span>
+                            <span class="hero-stat__value">Hace 2 horas</span>
+                        </div>
+                        <div class="hero-stat">
+                            <span class="hero-stat__label">Índice de respuesta</span>
+                            <span class="hero-stat__value hero-stat__value--accent">98%</span>
+                        </div>
                     </div>
-                    <div class="hero-stat">
-                        <span class="hero-stat__label">Índice de respuesta</span>
-                        <span class="hero-stat__value hero-stat__value--accent">98%</span>
-                    </div>
-                </div>
-            </section>
+                </section>
 
-            <section class="dashboard__section">
-                <div class="dashboard__section-heading">
-                    <h2 class="dashboard__section-title">Resumen de tus anuncios</h2>
-                    <a href="#" class="link-muted">Ver todos</a>
-                </div>
-                <div class="summary-grid">
-                    <div class="card summary-card">
-                        <div class="summary-card__icon summary-card__icon--primary"></div>
-                        <div>
-                            <h3 class="summary-card__title">Publicadas</h3>
-                            <p class="summary-card__number">0</p>
-                        </div>
-                        <span class="summary-card__trend summary-card__trend--up">+12%</span>
-                    </div>
-                    <div class="card summary-card">
-                        <div class="summary-card__icon summary-card__icon--warning"></div>
-                        <div>
-                            <h3 class="summary-card__title">Borradores</h3>
-                            <p class="summary-card__number">0</p>
-                        </div>
-                        <span class="summary-card__trend summary-card__trend--neutral">-</span>
-                    </div>
-                    <div class="card summary-card">
-                        <div class="summary-card__icon summary-card__icon--info"></div>
-                        <div>
-                            <h3 class="summary-card__title">En revisión</h3>
-                            <p class="summary-card__number">0</p>
-                        </div>
-                        <span class="summary-card__trend summary-card__trend--up">+4%</span>
-                    </div>
-                    <div class="card summary-card">
-                        <div class="summary-card__icon summary-card__icon--muted"></div>
-                        <div>
-                            <h3 class="summary-card__title">Pausadas</h3>
-                            <p class="summary-card__number">0</p>
-                        </div>
-                        <span class="summary-card__trend summary-card__trend--down">-6%</span>
-                    </div>
-                </div>
-            </section>
-
-            <section class="dashboard__section">
-                <div class="dashboard__section-heading">
-                    <h2 class="dashboard__section-title">Acciones rápidas</h2>
-                </div>
-                <div class="quick-actions">
-                    <a href="#" class="card quick-action">
-                        <div class="quick-action__icon quick-action__icon--blue"></div>
-                        <div>
-                            <h3 class="quick-action__title">Publicar propiedad</h3>
-                            <p class="quick-action__description">Carga fotos, características y fija el precio ideal.</p>
-                        </div>
-                    </a>
-                    <a href="#" class="card quick-action">
-                        <div class="quick-action__icon quick-action__icon--green"></div>
-                        <div>
-                            <h3 class="quick-action__title">Gestionar leads</h3>
-                            <p class="quick-action__description">Organiza tus contactos y automatiza seguimientos.</p>
-                        </div>
-                    </a>
-                    <a href="#" class="card quick-action">
-                        <div class="quick-action__icon quick-action__icon--orange"></div>
-                        <div>
-                            <h3 class="quick-action__title">Programar open house</h3>
-                            <p class="quick-action__description">Coordina visitas con tus clientes potenciales.</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="dashboard__section dashboard__section--split">
-                <div class="dashboard__column">
+                <section class="dashboard__section">
                     <div class="dashboard__section-heading">
-                        <h2 class="dashboard__section-title">Analytics</h2>
-                        <a href="#" class="link-muted">Ver reportes</a>
+                        <h2 class="dashboard__section-title">Resumen de tus anuncios</h2>
+                        <a href="#" class="link-muted">Ver todos</a>
                     </div>
-                    <div class="analytics-grid">
-                        <div class="analytics__metrics">
-                            <div class="card metric-pill">
-                                <div>
-                                    <span class="metric-pill__title">Vistas totales</span>
-                                    <span class="metric-pill__description">Últimos 30 días</span>
-                                </div>
-                                <span class="metric-pill__number">0</span>
+                    <div class="summary-grid">
+                        <div class="card summary-card">
+                            <div class="summary-card__icon summary-card__icon--primary"></div>
+                            <div>
+                                <h3 class="summary-card__title">Publicadas</h3>
+                                <p class="summary-card__number">0</p>
                             </div>
-                            <div class="card metric-pill">
-                                <div>
-                                    <span class="metric-pill__title">Consultas recibidas</span>
-                                    <span class="metric-pill__description">Comparado con el mes pasado</span>
-                                </div>
-                                <span class="metric-pill__number">0</span>
-                            </div>
-                            <div class="card metric-pill">
-                                <div>
-                                    <span class="metric-pill__title">Chats activos</span>
-                                    <span class="metric-pill__description">Tiempo promedio de respuesta</span>
-                                </div>
-                                <span class="metric-pill__number">0</span>
-                            </div>
+                            <span class="summary-card__trend summary-card__trend--up">+12%</span>
                         </div>
-                        <div class="card analytics__chart">
-                            <p class="analytics__chart-title">Interacción semanal</p>
-                            <div class="chart-placeholder">
-                                <div class="chart-placeholder__bar" style="height: 60%;"></div>
-                                <div class="chart-placeholder__bar" style="height: 80%;"></div>
-                                <div class="chart-placeholder__bar" style="height: 40%;"></div>
-                                <div class="chart-placeholder__bar" style="height: 70%;"></div>
-                                <div class="chart-placeholder__bar" style="height: 50%;"></div>
+                        <div class="card summary-card">
+                            <div class="summary-card__icon summary-card__icon--warning"></div>
+                            <div>
+                                <h3 class="summary-card__title">Borradores</h3>
+                                <p class="summary-card__number">0</p>
                             </div>
+                            <span class="summary-card__trend summary-card__trend--neutral">-</span>
+                        </div>
+                        <div class="card summary-card">
+                            <div class="summary-card__icon summary-card__icon--info"></div>
+                            <div>
+                                <h3 class="summary-card__title">En revisión</h3>
+                                <p class="summary-card__number">0</p>
+                            </div>
+                            <span class="summary-card__trend summary-card__trend--up">+4%</span>
+                        </div>
+                        <div class="card summary-card">
+                            <div class="summary-card__icon summary-card__icon--muted"></div>
+                            <div>
+                                <h3 class="summary-card__title">Pausadas</h3>
+                                <p class="summary-card__number">0</p>
+                            </div>
+                            <span class="summary-card__trend summary-card__trend--down">-6%</span>
                         </div>
                     </div>
-                </div>
-                <div class="dashboard__column">
-                    <div class="dashboard__section-heading">
-                        <h2 class="dashboard__section-title">Actividad reciente</h2>
-                        <a href="#" class="link-muted">Ver historial</a>
-                    </div>
-                    <ul class="card activity-feed">
-                        <li class="activity-feed__item">
-                            <span class="activity-feed__bullet activity-feed__bullet--highlight"></span>
-                            <div>
-                                <p class="activity-feed__title">Nuevo lead agregado</p>
-                                <p class="activity-feed__meta">María López &bull; Hace 10 minutos</p>
-                            </div>
-                        </li>
-                        <li class="activity-feed__item">
-                            <span class="activity-feed__bullet"></span>
-                            <div>
-                                <p class="activity-feed__title">Se actualizó el precio de "Casa Centro"</p>
-                                <p class="activity-feed__meta">Por ti &bull; Hace 3 horas</p>
-                            </div>
-                        </li>
-                        <li class="activity-feed__item">
-                            <span class="activity-feed__bullet"></span>
-                            <div>
-                                <p class="activity-feed__title">Recibiste un mensaje de Carlos Peña</p>
-                                <p class="activity-feed__meta">Hace 5 horas</p>
-                            </div>
-                        </li>
-                        <li class="activity-feed__item">
-                            <span class="activity-feed__bullet"></span>
-                            <div>
-                                <p class="activity-feed__title">Revisión pendiente en "Departamento Vista Mar"</p>
-                                <p class="activity-feed__meta">Hace 1 día</p>
-                            </div>
-                        </li>
-                    </ul>
-                </div>
-            </section>
+                </section>
 
-            <section class="dashboard__section">
-                <div class="dashboard__section-heading">
-                    <h2 class="dashboard__section-title">Alertas</h2>
-                    <button class="dashboard__action-btn dashboard__action-btn--ghost">Configurar alertas</button>
+                <section class="dashboard__section">
+                    <div class="dashboard__section-heading">
+                        <h2 class="dashboard__section-title">Acciones rápidas</h2>
+                    </div>
+                    <div class="quick-actions">
+                        <a href="#" class="card quick-action">
+                            <div class="quick-action__icon quick-action__icon--blue"></div>
+                            <div>
+                                <h3 class="quick-action__title">Publicar propiedad</h3>
+                                <p class="quick-action__description">Carga fotos, características y fija el precio ideal.</p>
+                            </div>
+                        </a>
+                        <a href="#" class="card quick-action">
+                            <div class="quick-action__icon quick-action__icon--green"></div>
+                            <div>
+                                <h3 class="quick-action__title">Gestionar leads</h3>
+                                <p class="quick-action__description">Organiza tus contactos y automatiza seguimientos.</p>
+                            </div>
+                        </a>
+                        <a href="#" class="card quick-action">
+                            <div class="quick-action__icon quick-action__icon--orange"></div>
+                            <div>
+                                <h3 class="quick-action__title">Programar open house</h3>
+                                <p class="quick-action__description">Coordina visitas con tus clientes potenciales.</p>
+                            </div>
+                        </a>
+                    </div>
+                </section>
+
+                <section class="dashboard__section dashboard__section--split">
+                    <div class="dashboard__column">
+                        <div class="dashboard__section-heading">
+                            <h2 class="dashboard__section-title">Analytics</h2>
+                            <a href="#" class="link-muted">Ver reportes</a>
+                        </div>
+                        <div class="analytics-grid">
+                            <div class="analytics__metrics">
+                                <div class="card metric-pill">
+                                    <div>
+                                        <span class="metric-pill__title">Vistas totales</span>
+                                        <span class="metric-pill__description">Últimos 30 días</span>
+                                    </div>
+                                    <span class="metric-pill__number">0</span>
+                                </div>
+                                <div class="card metric-pill">
+                                    <div>
+                                        <span class="metric-pill__title">Consultas recibidas</span>
+                                        <span class="metric-pill__description">Comparado con el mes pasado</span>
+                                    </div>
+                                    <span class="metric-pill__number">0</span>
+                                </div>
+                                <div class="card metric-pill">
+                                    <div>
+                                        <span class="metric-pill__title">Chats activos</span>
+                                        <span class="metric-pill__description">Tiempo promedio de respuesta</span>
+                                    </div>
+                                    <span class="metric-pill__number">0</span>
+                                </div>
+                            </div>
+                            <div class="card analytics__chart">
+                                <p class="analytics__chart-title">Interacción semanal</p>
+                                <div class="chart-placeholder">
+                                    <div class="chart-placeholder__bar" style="height: 60%;"></div>
+                                    <div class="chart-placeholder__bar" style="height: 80%;"></div>
+                                    <div class="chart-placeholder__bar" style="height: 40%;"></div>
+                                    <div class="chart-placeholder__bar" style="height: 70%;"></div>
+                                    <div class="chart-placeholder__bar" style="height: 50%;"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="dashboard__column">
+                        <div class="dashboard__section-heading">
+                            <h2 class="dashboard__section-title">Actividad reciente</h2>
+                            <a href="#" class="link-muted">Ver historial</a>
+                        </div>
+                        <ul class="card activity-feed">
+                            <li class="activity-feed__item">
+                                <span class="activity-feed__bullet activity-feed__bullet--highlight"></span>
+                                <div>
+                                    <p class="activity-feed__title">Nuevo lead agregado</p>
+                                    <p class="activity-feed__meta">María López &bull; Hace 10 minutos</p>
+                                </div>
+                            </li>
+                            <li class="activity-feed__item">
+                                <span class="activity-feed__bullet"></span>
+                                <div>
+                                    <p class="activity-feed__title">Se actualizó el precio de "Casa Centro"</p>
+                                    <p class="activity-feed__meta">Por ti &bull; Hace 3 horas</p>
+                                </div>
+                            </li>
+                            <li class="activity-feed__item">
+                                <span class="activity-feed__bullet"></span>
+                                <div>
+                                    <p class="activity-feed__title">Recibiste un mensaje de Carlos Peña</p>
+                                    <p class="activity-feed__meta">Hace 5 horas</p>
+                                </div>
+                            </li>
+                            <li class="activity-feed__item">
+                                <span class="activity-feed__bullet"></span>
+                                <div>
+                                    <p class="activity-feed__title">Revisión pendiente en "Departamento Vista Mar"</p>
+                                    <p class="activity-feed__meta">Hace 1 día</p>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                </section>
+
+                <section class="dashboard__section">
+                    <div class="dashboard__section-heading">
+                        <h2 class="dashboard__section-title">Alertas</h2>
+                        <button class="dashboard__action-btn dashboard__action-btn--ghost">Configurar alertas</button>
+                    </div>
+                    <div class="alerts-grid">
+                        <div class="card alert-card alert-card--danger">
+                            <div class="alert-card__info">
+                                <h3 class="alert-card__title">Anuncios rechazados</h3>
+                                <p class="alert-card__subtitle">Loft en Cancún</p>
+                                <p class="alert-card__description">Revisa la calidad de las imágenes y la descripción del inmueble.</p>
+                            </div>
+                            <a href="#" class="btn btn--rounded">Ver motivos</a>
+                        </div>
+                        <div class="card alert-card alert-card--warning">
+                            <div class="alert-card__info">
+                                <h3 class="alert-card__title">Mensajes sin contestar</h3>
+                                <p class="alert-card__subtitle">Juan Martínez</p>
+                                <p class="alert-card__description">Tu tiempo de respuesta supera las 4 horas.</p>
+                            </div>
+                            <a href="#" class="btn btn--rounded">Responder</a>
+                        </div>
+                        <div class="card alert-card alert-card--info">
+                            <div class="alert-card__info">
+                                <h3 class="alert-card__title">Falta verificar cuenta</h3>
+                                <p class="alert-card__description">Sube los documentos restantes para desbloquear más beneficios.</p>
+                            </div>
+                            <a href="#" class="btn btn--rounded">Continuar</a>
+                        </div>
+                    </div>
+                </section>
+            </div>
+
+            <div class="profile__panel" data-section="propiedades">
+                <div class="dashboard__breadcrumb">
+                    <span class="breadcrumb__label">Panel</span>
+                    <span class="breadcrumb__divider">/</span>
+                    <span class="breadcrumb__current">Mis propiedades</span>
                 </div>
-                <div class="alerts-grid">
-                    <div class="card alert-card alert-card--danger">
-                        <div class="alert-card__info">
-                            <h3 class="alert-card__title">Anuncios rechazados</h3>
-                            <p class="alert-card__subtitle">Loft en Cancún</p>
-                            <p class="alert-card__description">Revisa la calidad de las imágenes y la descripción del inmueble.</p>
-                        </div>
-                        <a href="#" class="btn btn--rounded">Ver motivos</a>
+
+                <section class="dashboard__section">
+                    <div class="dashboard__section-heading">
+                        <h2 class="dashboard__section-title">Gestiona tu portafolio</h2>
+                        <button class="dashboard__action-btn dashboard__action-btn--primary">Publicar propiedad</button>
                     </div>
-                    <div class="card alert-card alert-card--warning">
-                        <div class="alert-card__info">
-                            <h3 class="alert-card__title">Mensajes sin contestar</h3>
-                            <p class="alert-card__subtitle">Juan Martínez</p>
-                            <p class="alert-card__description">Tu tiempo de respuesta supera las 4 horas.</p>
+                    <div class="card properties-empty">
+                        <div class="properties-empty__illustration" aria-hidden="true"></div>
+                        <div class="properties-empty__content">
+                            <h3 class="properties-empty__title">Aún no tienes propiedades publicadas</h3>
+                            <p class="properties-empty__description">Comparte tu primera propiedad para comenzar a recibir clientes potenciales y seguimiento inteligente.</p>
+                            <a href="#" class="dashboard__action-btn dashboard__action-btn--primary">Publicar mi primera propiedad</a>
+                            <p class="properties-empty__note">¿Necesitas ayuda? Consulta nuestra guía para preparar un anuncio profesional.</p>
                         </div>
-                        <a href="#" class="btn btn--rounded">Responder</a>
                     </div>
-                    <div class="card alert-card alert-card--info">
-                        <div class="alert-card__info">
-                            <h3 class="alert-card__title">Falta verificar cuenta</h3>
-                            <p class="alert-card__description">Sube los documentos restantes para desbloquear más beneficios.</p>
-                        </div>
-                        <a href="#" class="btn btn--rounded">Continuar</a>
+                </section>
+
+                <section class="dashboard__section">
+                    <div class="properties-tips card">
+                        <h2 class="properties-tips__title">Recomendaciones para destacar tus anuncios</h2>
+                        <ul class="properties-tips__list">
+                            <li>Organiza fotografías en alta resolución y destaca los espacios clave.</li>
+                            <li>Describe atributos únicos: amenidades, ubicación estratégica y tipo de acabados.</li>
+                            <li>Define un precio competitivo respaldado por análisis comparativos.</li>
+                            <li>Completa toda la información de contacto para agilizar tus negociaciones.</li>
+                        </ul>
                     </div>
-                </div>
-            </section>
+                </section>
+            </div>
         </main>
     </div>
 
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const menuLinks = document.querySelectorAll('.sidebar__menu-link[data-section]');
+            const panels = document.querySelectorAll('.profile__panel');
+
+            menuLinks.forEach(link => {
+                link.addEventListener('click', event => {
+                    event.preventDefault();
+                    const targetSection = link.dataset.section;
+
+                    if (!targetSection) {
+                        return;
+                    }
+
+                    menuLinks.forEach(menuLink => menuLink.classList.remove('sidebar__menu-link--active'));
+                    link.classList.add('sidebar__menu-link--active');
+
+                    panels.forEach(panel => {
+                        panel.classList.toggle('profile__panel--active', panel.dataset.section === targetSection);
+                    });
+                });
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add tab switching logic in the profile sidebar between Inicio and Mis propiedades
- create an empty state and guidance content for the Mis propiedades panel with matching styling
- extend profile styles with reusable panel visibility helpers and empty state design

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d75aa6c7a48320a792e1d57751de53