### PR TITLE
Improve profile dashboard responsiveness

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6189,6 +6189,76 @@ body.profile-page {
     background: linear-gradient(135deg, #eef2f7 0%, #f7f9fc 50%, #ffffff 100%);
 }
 
+/* Botón para abrir el menú lateral en pantallas pequeñas */
+.profile__menu-toggle {
+    display: none;
+    align-items: center;
+    gap: 12px;
+    background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+    color: #ffffff;
+    font-weight: 600;
+    border: none;
+    border-radius: 999px;
+    padding: 12px 20px;
+    margin: 20px 20px 0;
+    cursor: pointer;
+    box-shadow: 0 14px 30px rgba(37, 99, 235, 0.28);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    position: relative;
+    z-index: 95;
+}
+
+.profile__menu-toggle:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 36px rgba(37, 99, 235, 0.32);
+}
+
+.profile__menu-toggle:focus-visible {
+    outline: 3px solid rgba(37, 99, 235, 0.35);
+    outline-offset: 3px;
+}
+
+.profile__menu-toggle-icon {
+    position: relative;
+    width: 20px;
+    height: 2px;
+    background: currentColor;
+    border-radius: 999px;
+    transition: background 0.3s ease;
+}
+
+.profile__menu-toggle-icon::before,
+.profile__menu-toggle-icon::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: currentColor;
+    border-radius: 999px;
+    transition: transform 0.3s ease;
+}
+
+.profile__menu-toggle-icon::before {
+    top: -6px;
+}
+
+.profile__menu-toggle-icon::after {
+    top: 6px;
+}
+
+.profile__menu-toggle--active .profile__menu-toggle-icon {
+    background: transparent;
+}
+
+.profile__menu-toggle--active .profile__menu-toggle-icon::before {
+    transform: translateY(6px) rotate(45deg);
+}
+
+.profile__menu-toggle--active .profile__menu-toggle-icon::after {
+    transform: translateY(-6px) rotate(-45deg);
+}
+
 /* --- Bloque del Sidebar --- */
 .sidebar {
     position: fixed;
@@ -6203,6 +6273,7 @@ body.profile-page {
     display: flex;
     flex-direction: column;
     gap: 24px;
+    transition: transform 0.3s ease;
 }
 
 /* --- Elementos del Perfil en el Sidebar --- */
@@ -6289,6 +6360,22 @@ body.profile-page {
 
 .profile__panel--active {
     display: block;
+}
+
+.profile__menu-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    z-index: 90;
+    display: none;
+}
+
+.profile__menu-overlay--visible {
+    display: block;
+}
+
+body.profile-page.profile-page--menu-open {
+    overflow: hidden;
 }
 
 .properties-empty {
@@ -6898,4 +6985,163 @@ DASHBOARD DEL PERFIL
 .profile-page .btn--rounded:hover {
     transform: translateY(-2px);
     box-shadow: 0 16px 32px rgba(93, 109, 126, 0.32);
+}
+
+@media (max-width: 992px) {
+    .profile {
+        flex-direction: column;
+    }
+
+    .profile__menu-toggle {
+        display: inline-flex;
+    }
+
+    .sidebar {
+        transform: translateX(-100%);
+        width: 280px;
+        max-width: 80%;
+        height: 100vh;
+    }
+
+    .sidebar.sidebar--open {
+        transform: translateX(0);
+    }
+
+    .sidebar__profile {
+        margin-bottom: 20px;
+    }
+
+    .sidebar__menu {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .profile__menu-overlay {
+        display: none;
+    }
+
+    .profile__menu-overlay.profile__menu-overlay--visible {
+        display: block;
+    }
+
+    .profile__main-content {
+        margin-left: 0;
+        padding: 32px 24px 40px;
+    }
+
+    .dashboard__actions {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .dashboard__action-btn {
+        flex: 1 1 220px;
+        justify-content: center;
+        display: inline-flex;
+        text-align: center;
+    }
+
+    .dashboard__hero {
+        grid-template-columns: 1fr;
+        text-align: center;
+        padding: 28px;
+    }
+
+    .dashboard__hero-info {
+        align-items: center;
+    }
+
+    .dashboard__hero-status {
+        justify-content: center;
+    }
+
+    .dashboard__hero-stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .summary-grid,
+    .quick-actions,
+    .dashboard__section--split,
+    .analytics-grid,
+    .alerts-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .dashboard__section-heading {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+
+    .dashboard__section-heading .link-muted,
+    .dashboard__section-heading .dashboard__action-btn {
+        align-self: stretch;
+        text-align: center;
+    }
+
+    .properties-empty {
+        flex-direction: column;
+        text-align: center;
+        align-items: center;
+    }
+
+    .properties-empty__illustration {
+        margin-bottom: 12px;
+    }
+}
+
+@media (max-width: 720px) {
+    .dashboard__hero-stats {
+        grid-template-columns: 1fr;
+    }
+
+    .summary-grid,
+    .quick-actions,
+    .dashboard__section--split,
+    .analytics-grid,
+    .alerts-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .dashboard__actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .dashboard__action-btn {
+        width: 100%;
+    }
+
+    .profile__menu-toggle {
+        margin: 16px 16px 0;
+    }
+
+    .profile__main-content {
+        padding: 28px 18px 36px;
+    }
+}
+
+@media (max-width: 480px) {
+    .profile__menu-toggle {
+        font-size: 0.95rem;
+        padding: 10px 18px;
+    }
+
+    .dashboard__hero-title {
+        font-size: 28px;
+    }
+
+    .summary-card__number {
+        font-size: 30px;
+    }
+
+    .properties-empty,
+    .properties-tips {
+        padding: 24px 20px;
+    }
+
+    .properties-empty__description {
+        max-width: none;
+    }
 }

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -1,6 +1,50 @@
 document.addEventListener('DOMContentLoaded', () => {
     const menuLinks = document.querySelectorAll('.sidebar__menu-link[data-section]');
     const panels = document.querySelectorAll('.profile__panel');
+    const sidebar = document.querySelector('.sidebar');
+    const menuToggle = document.querySelector('.profile__menu-toggle');
+    const menuOverlay = document.querySelector('.profile__menu-overlay');
+    const profileBody = document.body.classList.contains('profile-page') ? document.body : null;
+
+    const setMenuState = (isOpen) => {
+        if (!sidebar) {
+            return;
+        }
+
+        sidebar.classList.toggle('sidebar--open', isOpen);
+
+        if (menuOverlay) {
+            menuOverlay.classList.toggle('profile__menu-overlay--visible', isOpen);
+        }
+
+        if (menuToggle) {
+            menuToggle.classList.toggle('profile__menu-toggle--active', isOpen);
+            menuToggle.setAttribute('aria-expanded', String(isOpen));
+        }
+
+        if (profileBody) {
+            profileBody.classList.toggle('profile-page--menu-open', isOpen);
+        }
+    };
+
+    const closeMenuOnLargeScreens = () => {
+        if (window.matchMedia('(min-width: 993px)').matches) {
+            setMenuState(false);
+        }
+    };
+
+    if (menuToggle) {
+        menuToggle.addEventListener('click', () => {
+            const isOpen = sidebar ? sidebar.classList.contains('sidebar--open') : false;
+            setMenuState(!isOpen);
+        });
+    }
+
+    if (menuOverlay) {
+        menuOverlay.addEventListener('click', () => setMenuState(false));
+    }
+
+    window.addEventListener('resize', closeMenuOnLargeScreens);
 
     const loadPanelContent = (panel) => {
         const source = panel.dataset.src;
@@ -42,6 +86,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 const isActive = panel.dataset.section === targetSection;
                 panel.classList.toggle('profile__panel--active', isActive);
             });
+
+            if (window.matchMedia('(max-width: 992px)').matches) {
+                setMenuState(false);
+            }
         });
     });
 });

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -10,7 +10,11 @@
 <body class="profile-page">
 
     <div class="profile">
-        <aside class="sidebar">
+        <button class="profile__menu-toggle" type="button" aria-controls="profile-sidebar" aria-expanded="false">
+            <span class="profile__menu-toggle-icon" aria-hidden="true"></span>
+            Menú
+        </button>
+        <aside class="sidebar" id="profile-sidebar">
             <div class="sidebar__profile">
                 <img src="assets/images/iconcaracteristic/account-icon.png" alt="Foto de perfil" class="sidebar__profile-picture">
                 <div class="sidebar__profile-info">
@@ -41,6 +45,7 @@
                 </ul>
             </nav>
         </aside>
+        <div class="profile__menu-overlay" data-menu-overlay></div>
 
         <main class="profile__main-content">
             <div class="profile__panel profile__panel--active" data-section="inicio" data-src="assets/templates/profile/inicio.html"></div>


### PR DESCRIPTION
## Summary
- add a mobile menu toggle and overlay so the profile sidebar can slide in on small screens
- refine profile dashboard layouts with responsive breakpoints for the hero, summaries, quick actions, and properties modules
- update the profile script to open and close the sidebar menu and keep state in sync across viewports

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d85174709c8320ae4832742bc40064