### PR TITLE
Add property publication wizard to profile dashboard

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6899,3 +6899,472 @@ DASHBOARD DEL PERFIL
     transform: translateY(-2px);
     box-shadow: 0 16px 32px rgba(93, 109, 126, 0.32);
 }
+
+/* ================================================= */
+/* === PUBLICAR PROPIEDAD (WIZARD) === */
+/* ================================================= */
+
+.property-wizard {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 48px;
+    z-index: 999;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.property-wizard--hidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.property-wizard__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(4px);
+}
+
+.property-wizard__dialog {
+    position: relative;
+    background: #fff;
+    border-radius: 20px;
+    box-shadow: 0 30px 80px rgba(15, 23, 42, 0.28);
+    width: min(960px, 100%);
+    max-height: calc(100vh - 96px);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    animation: fadeIn 0.4s ease;
+}
+
+.property-wizard__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+    padding: 32px 36px 24px;
+    border-bottom: 1px solid #eef2f7;
+    background: linear-gradient(135deg, rgba(52, 152, 219, 0.12), transparent 70%);
+}
+
+.property-wizard__eyebrow {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #3498db;
+    margin-bottom: 4px;
+}
+
+.property-wizard__title {
+    font-size: 26px;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 8px;
+}
+
+.property-wizard__subtitle {
+    color: #6b7280;
+    max-width: 520px;
+    font-size: 15px;
+}
+
+.property-wizard__close {
+    border: none;
+    background: rgba(255, 255, 255, 0.7);
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    font-size: 24px;
+    font-weight: 700;
+    color: #1f2937;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.property-wizard__close:hover {
+    background: rgba(255, 255, 255, 0.95);
+    transform: scale(1.05);
+}
+
+.property-wizard__steps {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 12px;
+    padding: 24px 36px 0;
+    list-style: none;
+    margin: 0;
+}
+
+.property-wizard__step-indicator {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding-bottom: 24px;
+    color: #9ca3af;
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.property-wizard__step-indicator::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    height: 4px;
+    border-radius: 999px;
+    background: #e5e7eb;
+}
+
+.property-wizard__step-indicator--active,
+.property-wizard__step-indicator--completed {
+    color: #1f2937;
+}
+
+.property-wizard__step-indicator--active::after {
+    background: linear-gradient(135deg, #3498db, #2ecc71);
+}
+
+.property-wizard__step-indicator--completed::after {
+    background: #2ecc71;
+}
+
+.property-wizard__step-number {
+    display: grid;
+    place-items: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background: #e5e7eb;
+    color: #1f2937;
+    font-weight: 700;
+    font-size: 18px;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+.property-wizard__step-indicator--active .property-wizard__step-number {
+    background: linear-gradient(135deg, #3498db, #2ecc71);
+    color: #fff;
+}
+
+.property-wizard__step-indicator--completed .property-wizard__step-number {
+    background: #2ecc71;
+    color: #fff;
+}
+
+.property-wizard__step-label {
+    text-align: center;
+}
+
+.property-wizard__form {
+    padding: 24px 36px 0;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.property-wizard__step {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    animation: fadeIn 0.3s ease;
+}
+
+.property-wizard__section-title {
+    font-size: 22px;
+    color: #1f2937;
+    margin: 0;
+}
+
+.property-wizard__section-description {
+    color: #6b7280;
+    font-size: 15px;
+}
+
+.property-wizard__options {
+    display: grid;
+    gap: 18px;
+}
+
+.property-wizard__options--grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.property-option,
+.property-type-card {
+    position: relative;
+    border: 1px solid #e5e7eb;
+    border-radius: 16px;
+    padding: 20px 24px;
+    background: #fff;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.property-option:hover,
+.property-type-card:hover {
+    border-color: rgba(52, 152, 219, 0.6);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    transform: translateY(-2px);
+}
+
+.property-option input,
+.property-type-card input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.property-option__content,
+.property-type-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.property-option__title,
+.property-type-card__title {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1f2937;
+}
+
+.property-option__description,
+.property-type-card__description {
+    font-size: 14px;
+    color: #6b7280;
+    line-height: 1.5;
+}
+
+.property-option input:checked ~ .property-option__content,
+.property-type-card input:checked ~ .property-type-card__content {
+    box-shadow: inset 0 0 0 2px #3498db;
+    background: rgba(52, 152, 219, 0.08);
+    border-radius: 12px;
+}
+
+.property-wizard__form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px 24px;
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.form-field--full {
+    grid-column: 1 / -1;
+}
+
+.form-field__label {
+    font-weight: 600;
+    color: #1f2937;
+    font-size: 15px;
+}
+
+.form-field__input,
+.form-field__textarea,
+.form-field__input-wrapper,
+.form-field select {
+    width: 100%;
+}
+
+.form-field__input,
+.form-field select {
+    border-radius: 12px;
+    border: 1px solid #d1d5db;
+    padding: 12px 16px;
+    font-size: 15px;
+    color: #1f2937;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field__textarea {
+    border-radius: 12px;
+    border: 1px solid #d1d5db;
+    padding: 14px 16px;
+    font-size: 15px;
+    color: #1f2937;
+    resize: vertical;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field__input:focus,
+.form-field__textarea:focus,
+.form-field select:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 4px rgba(52, 152, 219, 0.15);
+}
+
+.form-field__input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    border-radius: 12px;
+    border: 1px solid #d1d5db;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field__input-wrapper:focus-within {
+    border-color: #3498db;
+    box-shadow: 0 0 0 4px rgba(52, 152, 219, 0.15);
+}
+
+.form-field__prefix {
+    padding: 0 14px;
+    font-weight: 600;
+    color: #6b7280;
+}
+
+.form-field__input-wrapper .form-field__input {
+    border: none;
+    box-shadow: none;
+    padding-left: 0;
+}
+
+.form-field__hint {
+    font-size: 13px;
+    color: #6b7280;
+}
+
+.property-wizard__disclaimer {
+    margin-top: 16px;
+    background: rgba(52, 152, 219, 0.08);
+    border: 1px solid rgba(52, 152, 219, 0.25);
+    border-radius: 16px;
+    padding: 18px 20px;
+}
+
+.property-wizard__feedback {
+    display: none;
+    margin: 8px 36px 0;
+    padding: 14px 18px;
+    border-radius: 12px;
+    background: rgba(231, 76, 60, 0.08);
+    border: 1px solid rgba(231, 76, 60, 0.35);
+    color: #c0392b;
+    font-weight: 600;
+}
+
+.property-wizard__feedback--visible {
+    display: block;
+}
+
+.property-wizard__disclaimer-title {
+    font-size: 16px;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 10px;
+}
+
+.property-wizard__disclaimer-list {
+    margin: 0;
+    padding-left: 20px;
+    color: #4b5563;
+    display: grid;
+    gap: 6px;
+    font-size: 14px;
+}
+
+.property-wizard__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px 36px 32px;
+    border-top: 1px solid #eef2f7;
+    background: #fafbff;
+}
+
+.property-wizard__footer-actions {
+    display: flex;
+    gap: 12px;
+}
+
+.property-wizard__prev {
+    visibility: hidden;
+}
+
+.property-wizard__submit {
+    display: none;
+}
+
+.property-wizard__success {
+    position: absolute;
+    inset: 0;
+    padding: 60px 80px;
+    background: linear-gradient(135deg, rgba(46, 204, 113, 0.12), rgba(52, 152, 219, 0.08));
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 18px;
+    text-align: center;
+}
+
+.property-wizard__success-icon {
+    width: 84px;
+    height: 84px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #2ecc71, #27ae60);
+    position: relative;
+}
+
+.property-wizard__success-icon::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) rotate(-45deg);
+    width: 20px;
+    height: 40px;
+    border: solid #fff;
+    border-width: 0 8px 8px 0;
+    border-radius: 4px;
+}
+
+.property-wizard__success-title {
+    font-size: 26px;
+    font-weight: 700;
+    color: #14532d;
+}
+
+.property-wizard__success-message {
+    color: #14532d;
+    max-width: 480px;
+}
+
+@media (max-width: 1200px) {
+    .property-wizard {
+        padding: 32px;
+    }
+
+    .property-wizard__dialog {
+        width: min(840px, 100%);
+    }
+}
+
+@media (max-width: 992px) {
+    .property-wizard__steps {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        row-gap: 18px;
+    }
+
+    .property-wizard__form-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -2,6 +2,222 @@ document.addEventListener('DOMContentLoaded', () => {
     const menuLinks = document.querySelectorAll('.sidebar__menu-link[data-section]');
     const panels = document.querySelectorAll('.profile__panel');
 
+    const initializePropertiesPanel = (panel) => {
+        const wizard = panel.querySelector('.property-wizard');
+        if (!wizard) {
+            return;
+        }
+
+        const openButtons = panel.querySelectorAll('.js-open-listing-wizard');
+        const dialog = wizard.querySelector('.property-wizard__dialog');
+        const closeTriggers = wizard.querySelectorAll('[data-close-dialog]');
+        const form = wizard.querySelector('.property-wizard__form');
+        const steps = Array.from(form.querySelectorAll('.property-wizard__step'));
+        const stepIndicators = Array.from(wizard.querySelectorAll('.property-wizard__step-indicator'));
+        const previousButton = wizard.querySelector('.property-wizard__prev');
+        const nextButton = wizard.querySelector('.property-wizard__next');
+        const submitButton = wizard.querySelector('.property-wizard__submit');
+        const successState = wizard.querySelector('.property-wizard__success');
+        const feedback = wizard.querySelector('.property-wizard__feedback');
+        const photosInput = form.querySelector('#propertyPhotos');
+        const photosHint = form.querySelector('[data-photos-hint]');
+        let currentStep = 0;
+
+        const getPhotosValidationMessage = (count) => {
+            if (count === 0) {
+                return 'Selecciona al menos 5 fotografías para continuar.';
+            }
+            if (count < 5) {
+                const missing = 5 - count;
+                return `Añade ${missing} fotografía${missing === 1 ? '' : 's'} más.`;
+            }
+            if (count > 50) {
+                return 'El máximo permitido es de 50 fotografías.';
+            }
+            return '';
+        };
+
+        const updatePhotosHint = () => {
+            if (!photosInput || !photosHint) {
+                return;
+            }
+            const count = photosInput.files.length;
+            if (count === 0) {
+                photosHint.textContent = 'Selecciona imágenes en alta resolución. Puedes arrastrar y soltar varias a la vez.';
+                return;
+            }
+            photosHint.textContent = `${count} fotografía${count === 1 ? '' : 's'} seleccionada${count === 1 ? '' : 's'}.`;
+        };
+
+        const showFeedback = (message = '') => {
+            if (!feedback) {
+                return;
+            }
+            if (message) {
+                feedback.textContent = message;
+                feedback.classList.add('property-wizard__feedback--visible');
+            } else {
+                feedback.textContent = '';
+                feedback.classList.remove('property-wizard__feedback--visible');
+            }
+        };
+
+        const updateStepIndicators = (index) => {
+            stepIndicators.forEach((indicator, stepIndex) => {
+                indicator.classList.toggle('property-wizard__step-indicator--active', stepIndex === index);
+                indicator.classList.toggle('property-wizard__step-indicator--completed', stepIndex < index);
+            });
+        };
+
+        const showStep = (index) => {
+            steps.forEach((step, stepIndex) => {
+                if (stepIndex === index) {
+                    step.hidden = false;
+                } else {
+                    step.hidden = true;
+                }
+            });
+
+            updateStepIndicators(index);
+
+            previousButton.style.visibility = index === 0 ? 'hidden' : 'visible';
+            nextButton.style.display = index === steps.length - 1 ? 'none' : 'inline-flex';
+            submitButton.style.display = index === steps.length - 1 ? 'inline-flex' : 'none';
+        };
+
+        const validateStep = (index) => {
+            const stepElement = steps[index];
+            if (!stepElement) {
+                return true;
+            }
+
+            const controls = Array.from(stepElement.querySelectorAll('input, textarea, select'));
+
+            if (index === 0) {
+                const selectedOperation = form.querySelector('input[name="operation"]:checked');
+                if (!selectedOperation) {
+                    showFeedback('Selecciona si publicarás una propiedad en venta o renta.');
+                    return false;
+                }
+            }
+
+            if (index === 1) {
+                const selectedType = form.querySelector('input[name="propertyType"]:checked');
+                if (!selectedType) {
+                    showFeedback('Elige el tipo de propiedad para continuar.');
+                    return false;
+                }
+            }
+
+            for (const control of controls) {
+                if (control.type === 'file') {
+                    const message = getPhotosValidationMessage(control.files.length);
+                    control.setCustomValidity(message);
+                    if (!control.checkValidity()) {
+                        showFeedback(message);
+                        return false;
+                    }
+                    continue;
+                }
+
+                control.setCustomValidity('');
+                if (!control.checkValidity()) {
+                    control.reportValidity();
+                    return false;
+                }
+            }
+
+            showFeedback('');
+            return true;
+        };
+
+        const resetWizard = () => {
+            form.reset();
+            form.hidden = false;
+            successState.hidden = true;
+            currentStep = 0;
+            updatePhotosHint();
+            showFeedback('');
+            showStep(currentStep);
+        };
+
+        const openWizard = () => {
+            resetWizard();
+            wizard.classList.remove('property-wizard--hidden');
+            wizard.setAttribute('aria-hidden', 'false');
+            dialog.focus();
+        };
+
+        const closeWizard = () => {
+            wizard.classList.add('property-wizard--hidden');
+            wizard.setAttribute('aria-hidden', 'true');
+            resetWizard();
+        };
+
+        if (photosInput) {
+            photosInput.addEventListener('change', () => {
+                const message = getPhotosValidationMessage(photosInput.files.length);
+                photosInput.setCustomValidity(message);
+                updatePhotosHint();
+            });
+        }
+
+        openButtons.forEach(button => {
+            button.addEventListener('click', event => {
+                event.preventDefault();
+                openWizard();
+            });
+        });
+
+        closeTriggers.forEach(trigger => {
+            trigger.addEventListener('click', () => {
+                closeWizard();
+            });
+        });
+
+        wizard.addEventListener('keydown', event => {
+            if (event.key === 'Escape') {
+                closeWizard();
+            }
+        });
+
+        previousButton.addEventListener('click', () => {
+            if (currentStep > 0) {
+                currentStep -= 1;
+                showStep(currentStep);
+            }
+        });
+
+        nextButton.addEventListener('click', () => {
+            if (!validateStep(currentStep)) {
+                return;
+            }
+
+            if (currentStep < steps.length - 1) {
+                currentStep += 1;
+                showStep(currentStep);
+            }
+        });
+
+        form.addEventListener('submit', event => {
+            event.preventDefault();
+
+            if (!validateStep(currentStep)) {
+                return;
+            }
+
+            if (!form.checkValidity()) {
+                form.reportValidity();
+                return;
+            }
+
+            successState.hidden = false;
+            form.hidden = true;
+            showFeedback('');
+            stepIndicators.forEach(indicator => indicator.classList.add('property-wizard__step-indicator--completed'));
+        });
+    };
+
     const loadPanelContent = (panel) => {
         const source = panel.dataset.src;
         if (!source) {
@@ -17,6 +233,9 @@ document.addEventListener('DOMContentLoaded', () => {
             })
             .then(html => {
                 panel.innerHTML = html;
+                if (panel.dataset.section === 'propiedades') {
+                    initializePropertiesPanel(panel);
+                }
             })
             .catch(error => {
                 console.error(error);

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -7,18 +7,236 @@
 <section class="dashboard__section">
     <div class="dashboard__section-heading">
         <h2 class="dashboard__section-title">Gestiona tu portafolio</h2>
-        <button class="dashboard__action-btn dashboard__action-btn--primary">Publicar propiedad</button>
+        <button class="dashboard__action-btn dashboard__action-btn--primary js-open-listing-wizard">Publicar propiedad</button>
     </div>
     <div class="card properties-empty">
         <div class="properties-empty__illustration" aria-hidden="true"></div>
         <div class="properties-empty__content">
             <h3 class="properties-empty__title">Aún no tienes propiedades publicadas</h3>
             <p class="properties-empty__description">Comparte tu primera propiedad para comenzar a recibir clientes potenciales y seguimiento inteligente.</p>
-            <a href="#" class="dashboard__action-btn dashboard__action-btn--primary">Publicar mi primera propiedad</a>
+            <a href="#" class="dashboard__action-btn dashboard__action-btn--primary js-open-listing-wizard">Publicar mi primera propiedad</a>
             <p class="properties-empty__note">¿Necesitas ayuda? Consulta nuestra guía para preparar un anuncio profesional.</p>
         </div>
     </div>
 </section>
+
+<div class="property-wizard property-wizard--hidden" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="propertyWizardTitle">
+    <div class="property-wizard__backdrop" data-close-dialog></div>
+    <div class="property-wizard__dialog" role="document" tabindex="-1">
+        <header class="property-wizard__header">
+            <div>
+                <p class="property-wizard__eyebrow">Nueva publicación</p>
+                <h2 class="property-wizard__title" id="propertyWizardTitle">Crea un anuncio profesional</h2>
+                <p class="property-wizard__subtitle">Comparte los datos esenciales de tu propiedad y publícala cuando estés listo.</p>
+            </div>
+            <button class="property-wizard__close" type="button" aria-label="Cerrar" data-close-dialog>&times;</button>
+        </header>
+
+        <ol class="property-wizard__steps" role="list">
+            <li class="property-wizard__step-indicator property-wizard__step-indicator--active" data-step="0">
+                <span class="property-wizard__step-number">1</span>
+                <span class="property-wizard__step-label">Operación</span>
+            </li>
+            <li class="property-wizard__step-indicator" data-step="1">
+                <span class="property-wizard__step-number">2</span>
+                <span class="property-wizard__step-label">Tipo</span>
+            </li>
+            <li class="property-wizard__step-indicator" data-step="2">
+                <span class="property-wizard__step-number">3</span>
+                <span class="property-wizard__step-label">Detalles</span>
+            </li>
+            <li class="property-wizard__step-indicator" data-step="3">
+                <span class="property-wizard__step-number">4</span>
+                <span class="property-wizard__step-label">Características</span>
+            </li>
+            <li class="property-wizard__step-indicator" data-step="4">
+                <span class="property-wizard__step-number">5</span>
+                <span class="property-wizard__step-label">Precio</span>
+            </li>
+        </ol>
+
+        <form class="property-wizard__form" novalidate>
+            <section class="property-wizard__step" data-step-index="0">
+                <h3 class="property-wizard__section-title">¿Qué tipo de operación buscas?</h3>
+                <p class="property-wizard__section-description">Selecciona si publicarás una propiedad en venta o renta. Esto ayudará a mostrarla en el catálogo adecuado.</p>
+                <div class="property-wizard__options">
+                    <label class="property-option">
+                        <input type="radio" name="operation" value="venta" required>
+                        <span class="property-option__content">
+                            <span class="property-option__title">Venta</span>
+                            <span class="property-option__description">Publica propiedades en venta y destaca beneficios de inversión.</span>
+                        </span>
+                    </label>
+                    <label class="property-option">
+                        <input type="radio" name="operation" value="renta" required>
+                        <span class="property-option__content">
+                            <span class="property-option__title">Renta</span>
+                            <span class="property-option__description">Ideal para arrendamientos residenciales o comerciales.</span>
+                        </span>
+                    </label>
+                </div>
+            </section>
+
+            <section class="property-wizard__step" data-step-index="1" hidden>
+                <h3 class="property-wizard__section-title">Selecciona el tipo de propiedad</h3>
+                <p class="property-wizard__section-description">Escoge el tipo de inmueble que deseas promocionar.</p>
+                <div class="property-wizard__options property-wizard__options--grid">
+                    <label class="property-type-card">
+                        <input type="radio" name="propertyType" value="casa" required>
+                        <span class="property-type-card__content">
+                            <span class="property-type-card__title">Casa</span>
+                            <span class="property-type-card__description">Ideal para propiedades residenciales unifamiliares.</span>
+                        </span>
+                    </label>
+                    <label class="property-type-card">
+                        <input type="radio" name="propertyType" value="departamento" required>
+                        <span class="property-type-card__content">
+                            <span class="property-type-card__title">Departamento</span>
+                            <span class="property-type-card__description">Perfecto para condominios y lofts urbanos.</span>
+                        </span>
+                    </label>
+                    <label class="property-type-card">
+                        <input type="radio" name="propertyType" value="terreno" required>
+                        <span class="property-type-card__content">
+                            <span class="property-type-card__title">Terreno</span>
+                            <span class="property-type-card__description">Comparte lotes y predios listos para desarrollar.</span>
+                        </span>
+                    </label>
+                    <label class="property-type-card">
+                        <input type="radio" name="propertyType" value="desarrollo" required>
+                        <span class="property-type-card__content">
+                            <span class="property-type-card__title">Desarrollo</span>
+                            <span class="property-type-card__description">Presenta proyectos con múltiples unidades o etapas.</span>
+                        </span>
+                    </label>
+                </div>
+            </section>
+
+            <section class="property-wizard__step" data-step-index="2" hidden>
+                <h3 class="property-wizard__section-title">Agrega la información principal</h3>
+                <p class="property-wizard__section-description">Incluye fotografías, datos clave y localización precisa para mejorar la visibilidad de tu anuncio.</p>
+                <div class="property-wizard__form-grid">
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyPhotos">Fotografías (mínimo 5, máximo 50)</label>
+                        <input class="form-field__input" type="file" id="propertyPhotos" name="propertyPhotos" accept="image/*" multiple required>
+                        <p class="form-field__hint" data-photos-hint>Selecciona imágenes en alta resolución. Puedes arrastrar y soltar varias a la vez.</p>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyTitle">Título del anuncio</label>
+                        <input class="form-field__input" type="text" id="propertyTitle" name="propertyTitle" placeholder="Ej. Residencia contemporánea en Cedral" required>
+                    </div>
+                    <div class="form-field form-field--full">
+                        <label class="form-field__label" for="propertyDescription">Descripción</label>
+                        <textarea class="form-field__textarea" id="propertyDescription" name="propertyDescription" rows="5" placeholder="Describe los espacios, amenidades y ventajas competitivas" required></textarea>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyLocation">Ubicación</label>
+                        <input class="form-field__input" type="text" id="propertyLocation" name="propertyLocation" placeholder="Ciudad, colonia o desarrollo" required>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyAddress">Dirección completa</label>
+                        <input class="form-field__input" type="text" id="propertyAddress" name="propertyAddress" placeholder="Calle, número exterior e interior" required>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyLatitude">Latitud</label>
+                        <input class="form-field__input" type="text" id="propertyLatitude" name="propertyLatitude" placeholder="Ej. 21.234567" required>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyLongitude">Longitud</label>
+                        <input class="form-field__input" type="text" id="propertyLongitude" name="propertyLongitude" placeholder="Ej. -99.123456" required>
+                    </div>
+                </div>
+            </section>
+
+            <section class="property-wizard__step" data-step-index="3" hidden>
+                <h3 class="property-wizard__section-title">Características de la propiedad</h3>
+                <p class="property-wizard__section-description">Detalla las características para que los interesados tengan claridad sobre el inmueble.</p>
+                <div class="property-wizard__form-grid">
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyBedrooms">Habitaciones</label>
+                        <input class="form-field__input" type="number" id="propertyBedrooms" name="propertyBedrooms" min="0" placeholder="Ej. 3" required>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyBathrooms">Baños</label>
+                        <input class="form-field__input" type="number" id="propertyBathrooms" name="propertyBathrooms" min="0" placeholder="Ej. 2.5" step="0.5" required>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyParking">Estacionamientos</label>
+                        <input class="form-field__input" type="number" id="propertyParking" name="propertyParking" min="0" placeholder="Ej. 2" required>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertySize">Superficie construida (m²)</label>
+                        <input class="form-field__input" type="number" id="propertySize" name="propertySize" min="0" placeholder="Ej. 180" required>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyLand">Superficie de terreno (m²)</label>
+                        <input class="form-field__input" type="number" id="propertyLand" name="propertyLand" min="0" placeholder="Ej. 220">
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyAmenities">Amenidades destacadas</label>
+                        <textarea class="form-field__textarea" id="propertyAmenities" name="propertyAmenities" rows="4" placeholder="Ej. Alberca, gimnasio, roof garden, seguridad 24/7"></textarea>
+                    </div>
+                </div>
+            </section>
+
+            <section class="property-wizard__step" data-step-index="4" hidden>
+                <h3 class="property-wizard__section-title">Define el precio y publica</h3>
+                <p class="property-wizard__section-description">Establece el precio de mercado y confirma la publicación de la propiedad.</p>
+                <div class="property-wizard__form-grid">
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyPrice">Precio</label>
+                        <div class="form-field__input-wrapper">
+                            <span class="form-field__prefix">$</span>
+                            <input class="form-field__input" type="number" id="propertyPrice" name="propertyPrice" min="0" step="1000" placeholder="Ej. 2,350,000" required>
+                        </div>
+                    </div>
+                    <div class="form-field">
+                        <label class="form-field__label" for="propertyCurrency">Moneda</label>
+                        <select class="form-field__input" id="propertyCurrency" name="propertyCurrency" required>
+                            <option value="" disabled selected>Selecciona una opción</option>
+                            <option value="mxn">MXN - Peso mexicano</option>
+                            <option value="usd">USD - Dólar estadounidense</option>
+                        </select>
+                    </div>
+                    <div class="form-field form-field--full">
+                        <label class="form-field__label" for="propertyAvailability">Disponibilidad</label>
+                        <select class="form-field__input" id="propertyAvailability" name="propertyAvailability" required>
+                            <option value="" disabled selected>Selecciona una opción</option>
+                            <option value="inmediata">Entrega inmediata</option>
+                            <option value="en_construccion">En construcción</option>
+                            <option value="preventas">Preventas</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="property-wizard__disclaimer">
+                    <h4 class="property-wizard__disclaimer-title">Antes de publicar</h4>
+                    <ul class="property-wizard__disclaimer-list">
+                        <li>Verifica que la información sea correcta y que las fotografías representen el estado actual.</li>
+                        <li>Una vez publicada, podrás editar detalles desde el panel de propiedades.</li>
+                        <li>El equipo de DOMABLY revisará tu anuncio para mantener la calidad de la plataforma.</li>
+                    </ul>
+                </div>
+            </section>
+
+            <div class="property-wizard__feedback" aria-live="polite"></div>
+
+            <footer class="property-wizard__footer">
+                <button class="dashboard__action-btn dashboard__action-btn--ghost property-wizard__prev" type="button">Volver</button>
+                <div class="property-wizard__footer-actions">
+                    <button class="dashboard__action-btn dashboard__action-btn--primary property-wizard__next" type="button">Continuar</button>
+                    <button class="dashboard__action-btn dashboard__action-btn--primary property-wizard__submit" type="submit">Publicar propiedad</button>
+                </div>
+            </footer>
+        </form>
+
+        <div class="property-wizard__success" role="status" hidden>
+            <div class="property-wizard__success-icon" aria-hidden="true"></div>
+            <h3 class="property-wizard__success-title">¡Propiedad lista para revisión!</h3>
+            <p class="property-wizard__success-message">Hemos guardado toda la información. Podrás dar seguimiento y completar los datos restantes desde tu panel de propiedades.</p>
+            <button class="dashboard__action-btn dashboard__action-btn--primary" type="button" data-close-dialog>Cerrar</button>
+        </div>
+    </div>
+</div>
 
 <section class="dashboard__section">
     <div class="properties-tips card">


### PR DESCRIPTION
## Summary
- add a multi-step property publication wizard to the profile properties panel
- style the wizard with desktop-focused layouts and feedback messaging
- implement JavaScript logic for step navigation, validation, and success handling

## Testing
- No automated tests were run (front-end change only)


------
https://chatgpt.com/codex/tasks/task_e_68d8676431dc8320b452f11b5a991685