### PR TITLE
Add modal for publish property action in profile dashboard

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6368,6 +6368,92 @@ body.profile-page {
     line-height: 1.6;
 }
 
+.modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(17, 24, 39, 0.45);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.25s ease, visibility 0.25s ease;
+    z-index: 200;
+    padding: 24px;
+}
+
+.modal--visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal__overlay {
+    position: absolute;
+    inset: 0;
+}
+
+.modal__dialog {
+    position: relative;
+    background: #ffffff;
+    border-radius: 24px;
+    padding: 40px 48px;
+    max-width: 420px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+}
+
+.modal__title {
+    font-size: 28px;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 12px;
+}
+
+.modal__subtitle {
+    font-size: 16px;
+    color: #4b5563;
+    margin-bottom: 28px;
+}
+
+.modal__actions {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+}
+
+.modal__action {
+    flex: 1;
+    text-align: center;
+    border-radius: 12px;
+}
+
+.modal__action:not(.dashboard__action-btn--primary) {
+    background: #e5f2ff;
+    color: #1f2937;
+}
+
+.modal__action:not(.dashboard__action-btn--primary):hover {
+    background: #d6e9ff;
+}
+
+.modal__close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    background: transparent;
+    border: none;
+    font-size: 28px;
+    line-height: 1;
+    cursor: pointer;
+    color: #9ca3af;
+    transition: color 0.2s ease;
+}
+
+.modal__close:hover {
+    color: #4b5563;
+}
+
 /*
 =================================
 DASHBOARD DEL PERFIL

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -2,6 +2,67 @@ document.addEventListener('DOMContentLoaded', () => {
     const menuLinks = document.querySelectorAll('.sidebar__menu-link[data-section]');
     const panels = document.querySelectorAll('.profile__panel');
 
+    const setupPublishModal = (panel) => {
+        const modal = panel.querySelector('[data-modal="publish"]');
+        if (!modal) {
+            return;
+        }
+
+        const openButtons = panel.querySelectorAll('[data-modal-trigger="publish"]');
+        if (!openButtons.length) {
+            return;
+        }
+
+        const closers = modal.querySelectorAll('[data-modal-close]');
+
+        const updateAria = (isOpen) => {
+            modal.setAttribute('aria-hidden', String(!isOpen));
+            if (isOpen) {
+                modal.setAttribute('aria-modal', 'true');
+            } else {
+                modal.removeAttribute('aria-modal');
+            }
+        };
+
+        const closeModal = () => {
+            modal.classList.remove('modal--visible');
+            updateAria(false);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+
+        const handleKeyDown = (event) => {
+            if (event.key === 'Escape') {
+                closeModal();
+            }
+        };
+
+        const openModal = () => {
+            modal.classList.add('modal--visible');
+            updateAria(true);
+            document.addEventListener('keydown', handleKeyDown);
+        };
+
+        openButtons.forEach(button => {
+            button.addEventListener('click', event => {
+                event.preventDefault();
+                openModal();
+            });
+        });
+
+        closers.forEach(element => {
+            element.addEventListener('click', event => {
+                event.preventDefault();
+                closeModal();
+            });
+        });
+    };
+
+    const initializePanelFeatures = (panel) => {
+        if (panel.dataset.section === 'propiedades') {
+            setupPublishModal(panel);
+        }
+    };
+
     const loadPanelContent = (panel) => {
         const source = panel.dataset.src;
         if (!source) {
@@ -17,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
             })
             .then(html => {
                 panel.innerHTML = html;
+                initializePanelFeatures(panel);
             })
             .catch(error => {
                 console.error(error);
@@ -41,6 +103,9 @@ document.addEventListener('DOMContentLoaded', () => {
             panels.forEach(panel => {
                 const isActive = panel.dataset.section === targetSection;
                 panel.classList.toggle('profile__panel--active', isActive);
+                if (isActive && !panel.innerHTML.trim()) {
+                    loadPanelContent(panel);
+                }
             });
         });
     });

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -7,14 +7,14 @@
 <section class="dashboard__section">
     <div class="dashboard__section-heading">
         <h2 class="dashboard__section-title">Gestiona tu portafolio</h2>
-        <button class="dashboard__action-btn dashboard__action-btn--primary">Publicar propiedad</button>
+        <button class="dashboard__action-btn dashboard__action-btn--primary" data-modal-trigger="publish">Publicar propiedad</button>
     </div>
     <div class="card properties-empty">
         <div class="properties-empty__illustration" aria-hidden="true"></div>
         <div class="properties-empty__content">
             <h3 class="properties-empty__title">Aún no tienes propiedades publicadas</h3>
             <p class="properties-empty__description">Comparte tu primera propiedad para comenzar a recibir clientes potenciales y seguimiento inteligente.</p>
-            <a href="#" class="dashboard__action-btn dashboard__action-btn--primary">Publicar mi primera propiedad</a>
+            <a href="#" class="dashboard__action-btn dashboard__action-btn--primary" data-modal-trigger="publish">Publicar mi primera propiedad</a>
             <p class="properties-empty__note">¿Necesitas ayuda? Consulta nuestra guía para preparar un anuncio profesional.</p>
         </div>
     </div>
@@ -31,3 +31,16 @@
         </ul>
     </div>
 </section>
+
+<div class="modal" data-modal="publish" aria-hidden="true" role="dialog">
+    <div class="modal__overlay" data-modal-close></div>
+    <div class="modal__dialog" role="document">
+        <button class="modal__close" type="button" aria-label="Cerrar" data-modal-close>&times;</button>
+        <h2 class="modal__title">¿Qué buscas?</h2>
+        <p class="modal__subtitle">Selecciona la opción que mejor se adapte a tu objetivo.</p>
+        <div class="modal__actions">
+            <a href="#" class="dashboard__action-btn dashboard__action-btn--primary modal__action">Vender</a>
+            <a href="#" class="dashboard__action-btn modal__action">Rentar</a>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add a publish-property modal to the properties dashboard panel with vender and rentar options
- style the modal and wire up profile scripting to open and close it from existing action buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db30f798dc8320b7089454da3dfd51