### PR TITLE
Improve publish property modal UX

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6454,6 +6454,162 @@ body.profile-page {
     color: #4b5563;
 }
 
+.modal-publish {
+    padding: 44px 48px 40px;
+    text-align: left;
+}
+
+.modal-publish__summary {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    min-height: 32px;
+    margin-bottom: 12px;
+}
+
+.modal-publish__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: #eff6ff;
+    color: #1d4ed8;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.modal-publish__step {
+    display: none;
+    animation: modal-step-in 0.25s ease;
+}
+
+.modal-publish__step--active {
+    display: block;
+}
+
+@keyframes modal-step-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.modal-publish__options {
+    display: grid;
+    gap: 16px;
+    margin-top: 32px;
+}
+
+.modal-publish__options--grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.modal-publish__option {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 22px;
+    border-radius: 16px;
+    border: 1.5px solid #e5e7eb;
+    background: #ffffff;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    cursor: pointer;
+    text-align: left;
+}
+
+.modal-publish__option:hover,
+.modal-publish__option:focus {
+    border-color: #2563eb;
+    box-shadow: 0 14px 32px rgba(37, 99, 235, 0.15);
+    transform: translateY(-2px);
+    outline: none;
+}
+
+.modal-publish__option.is-selected {
+    border-color: #2563eb;
+    box-shadow: 0 16px 36px rgba(37, 99, 235, 0.18);
+}
+
+.modal-publish__icon {
+    width: 52px;
+    height: 52px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 14px;
+    background: #f1f5f9;
+}
+
+.modal-publish__icon svg {
+    width: 32px;
+    height: 32px;
+}
+
+.modal-publish__label {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1f2937;
+}
+
+.modal-publish__description {
+    font-size: 14px;
+    color: #4b5563;
+    line-height: 1.5;
+}
+
+.modal-publish__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: none;
+    background: transparent;
+    color: #2563eb;
+    font-weight: 600;
+    cursor: pointer;
+    margin-bottom: 12px;
+}
+
+.modal-publish__back:hover,
+.modal-publish__back:focus {
+    color: #1d4ed8;
+    text-decoration: underline;
+}
+
+.modal-publish__footer {
+    margin-top: 28px;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.modal-publish__footer [data-publish-finish][disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+@media (max-width: 600px) {
+    .modal__dialog {
+        padding: 32px 24px;
+    }
+
+    .modal-publish {
+        padding: 32px 24px;
+    }
+
+    .modal-publish__options--grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /*
 =================================
 DASHBOARD DEL PERFIL

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -14,6 +14,62 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const closers = modal.querySelectorAll('[data-modal-close]');
+        const steps = Array.from(modal.querySelectorAll('.modal-publish__step'));
+        const summaryBadges = {
+            purpose: modal.querySelector('[data-selection-purpose]'),
+            type: modal.querySelector('[data-selection-type]')
+        };
+        const purposeOptions = Array.from(modal.querySelectorAll('[data-purpose]'));
+        const typeOptions = Array.from(modal.querySelectorAll('[data-type]'));
+        const backButton = modal.querySelector('[data-publish-back]');
+        const finishButton = modal.querySelector('[data-publish-finish]');
+
+        let publishState = {
+            purpose: null,
+            type: null
+        };
+
+        const setBadge = (badge, label) => {
+            if (!badge) {
+                return;
+            }
+
+            if (label) {
+                badge.textContent = label;
+                badge.hidden = false;
+            } else {
+                badge.textContent = '';
+                badge.hidden = true;
+            }
+        };
+
+        const toggleOptionSelection = (options, activeOption) => {
+            options.forEach(option => {
+                const isActive = option === activeOption;
+                option.classList.toggle('is-selected', isActive);
+                option.setAttribute('aria-pressed', String(isActive));
+            });
+        };
+
+        const showStep = (stepName) => {
+            steps.forEach(step => {
+                const isActive = step.dataset.step === stepName;
+                step.classList.toggle('modal-publish__step--active', isActive);
+            });
+            modal.dataset.currentStep = stepName;
+        };
+
+        const resetPublishState = () => {
+            publishState = { purpose: null, type: null };
+            toggleOptionSelection(purposeOptions, null);
+            toggleOptionSelection(typeOptions, null);
+            setBadge(summaryBadges.purpose, '');
+            setBadge(summaryBadges.type, '');
+            if (finishButton) {
+                finishButton.disabled = true;
+            }
+            showStep('purpose');
+        };
 
         const updateAria = (isOpen) => {
             modal.setAttribute('aria-hidden', String(!isOpen));
@@ -37,6 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
         };
 
         const openModal = () => {
+            resetPublishState();
             modal.classList.add('modal--visible');
             updateAria(true);
             document.addEventListener('keydown', handleKeyDown);
@@ -55,6 +112,52 @@ document.addEventListener('DOMContentLoaded', () => {
                 closeModal();
             });
         });
+
+        purposeOptions.forEach(option => {
+            option.addEventListener('click', () => {
+                publishState.purpose = option.dataset.purpose || null;
+                toggleOptionSelection(purposeOptions, option);
+                setBadge(summaryBadges.purpose, option.dataset.label || '');
+                publishState.type = null;
+                toggleOptionSelection(typeOptions, null);
+                setBadge(summaryBadges.type, '');
+                if (finishButton) {
+                    finishButton.disabled = true;
+                }
+                showStep('type');
+            });
+        });
+
+        typeOptions.forEach(option => {
+            option.addEventListener('click', () => {
+                publishState.type = option.dataset.type || null;
+                toggleOptionSelection(typeOptions, option);
+                setBadge(summaryBadges.type, option.dataset.label || '');
+                if (finishButton) {
+                    finishButton.disabled = false;
+                }
+            });
+        });
+
+        if (backButton) {
+            backButton.addEventListener('click', event => {
+                event.preventDefault();
+                showStep('purpose');
+                if (finishButton) {
+                    finishButton.disabled = !publishState.type;
+                }
+            });
+        }
+
+        if (finishButton) {
+            finishButton.addEventListener('click', event => {
+                event.preventDefault();
+                if (finishButton.disabled) {
+                    return;
+                }
+                closeModal();
+            });
+        }
     };
 
     const initializePanelFeatures = (panel) => {

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -34,13 +34,98 @@
 
 <div class="modal" data-modal="publish" aria-hidden="true" role="dialog">
     <div class="modal__overlay" data-modal-close></div>
-    <div class="modal__dialog" role="document">
+    <div class="modal__dialog modal-publish" role="document">
         <button class="modal__close" type="button" aria-label="Cerrar" data-modal-close>&times;</button>
-        <h2 class="modal__title">¿Qué buscas?</h2>
-        <p class="modal__subtitle">Selecciona la opción que mejor se adapte a tu objetivo.</p>
-        <div class="modal__actions">
-            <a href="#" class="dashboard__action-btn dashboard__action-btn--primary modal__action">Vender</a>
-            <a href="#" class="dashboard__action-btn modal__action">Rentar</a>
+        <div class="modal-publish__summary" aria-live="polite">
+            <span class="modal-publish__badge" data-selection-purpose hidden></span>
+            <span class="modal-publish__badge" data-selection-type hidden></span>
+        </div>
+
+        <div class="modal-publish__step modal-publish__step--active" data-step="purpose" role="group" aria-labelledby="publish-purpose-title">
+            <h2 class="modal__title" id="publish-purpose-title">¿Qué deseas hacer?</h2>
+            <p class="modal__subtitle">Elige si quieres publicar una propiedad para venta o renta.</p>
+            <div class="modal-publish__options">
+                <button type="button" class="modal-publish__option" data-purpose="vender" data-label="Vender">
+                    <span class="modal-publish__icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                            <path d="M9 20.5 24 9l15 11.5v15.5a3 3 0 0 1-3 3H12a3 3 0 0 1-3-3V20.5Z" fill="#e8f5ff" stroke="#2563eb" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M19.5 33h9" stroke="#2563eb" stroke-width="2" stroke-linecap="round"/>
+                            <circle cx="24" cy="26" r="5" fill="#2563eb" fill-opacity="0.12" stroke="#2563eb" stroke-width="2"/>
+                            <text x="24" y="28" text-anchor="middle" font-size="9" font-family="'Inter', sans-serif" fill="#2563eb">$</text>
+                        </svg>
+                    </span>
+                    <span class="modal-publish__label">Vender</span>
+                    <span class="modal-publish__description">Encuentra compradores ideales para tu propiedad.</span>
+                </button>
+                <button type="button" class="modal-publish__option" data-purpose="rentar" data-label="Rentar">
+                    <span class="modal-publish__icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                            <path d="M16 22v-5.5L24 11l8 5.5V22" fill="#eef2ff" stroke="#4f46e5" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M14 22h20v14H14z" fill="#eef2ff" stroke="#4f46e5" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M24 26a4 4 0 1 1 0 8" stroke="#4f46e5" stroke-width="2" stroke-linecap="round"/>
+                            <path d="M24 26h4v8" stroke="#4f46e5" stroke-width="2" stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <span class="modal-publish__label">Rentar</span>
+                    <span class="modal-publish__description">Conecta con inquilinos confiables para tu inmueble.</span>
+                </button>
+            </div>
+        </div>
+
+        <div class="modal-publish__step" data-step="type" role="group" aria-labelledby="publish-type-title">
+            <button type="button" class="modal-publish__back" data-publish-back>
+                <span aria-hidden="true">&#8592;</span>
+                Volver
+            </button>
+            <h2 class="modal__title" id="publish-type-title">¿Qué tipo de propiedad publicarás?</h2>
+            <p class="modal__subtitle">Selecciona la categoría que mejor describe tu inmueble.</p>
+            <div class="modal-publish__options modal-publish__options--grid" role="list">
+                <button type="button" class="modal-publish__option" data-type="casa" data-label="Casa" role="listitem">
+                    <span class="modal-publish__icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                            <path d="M8 22 24 10l16 12v16H8Z" fill="#ecfdf5" stroke="#10b981" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M20 38V26h8v12" stroke="#10b981" stroke-width="2" stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <span class="modal-publish__label">Casa</span>
+                </button>
+                <button type="button" class="modal-publish__option" data-type="departamento" data-label="Departamento" role="listitem">
+                    <span class="modal-publish__icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                            <path d="M12 8h24v32H12z" fill="#eef2ff" stroke="#6366f1" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M18 16h4m4 0h4m-12 8h4m4 0h4m-12 8h4m4 0h4" stroke="#6366f1" stroke-width="2" stroke-linecap="round"/>
+                            <path d="M22 40v-6h4v6" stroke="#6366f1" stroke-width="2" stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <span class="modal-publish__label">Departamento</span>
+                </button>
+                <button type="button" class="modal-publish__option" data-type="terreno" data-label="Terreno" role="listitem">
+                    <span class="modal-publish__icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                            <path d="M6 34 24 14l18 20" fill="#fef3c7" stroke="#f59e0b" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M10 34h28" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+                            <path d="M18 26h12" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <span class="modal-publish__label">Terreno</span>
+                </button>
+                <button type="button" class="modal-publish__option" data-type="desarrollo" data-label="Desarrollo" role="listitem">
+                    <span class="modal-publish__icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                            <path d="M10 34V16l8-4v22" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M22 34V10l8 4v20" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M34 34V20l4 2v12" stroke="#0ea5e9" stroke-width="2" stroke-linejoin="round"/>
+                            <path d="M10 34h28" stroke="#0ea5e9" stroke-width="2" stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <span class="modal-publish__label">Desarrollo</span>
+                </button>
+            </div>
+            <footer class="modal-publish__footer">
+                <button type="button" class="dashboard__action-btn dashboard__action-btn--primary" data-publish-finish disabled>
+                    Continuar con la publicación
+                </button>
+            </footer>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- redesign the publish property modal into a guided flow that captures venta o renta followed by property type
- refresh the modal styling with professional cards, selection states, and inline SVG icons
- extend the profile dashboard script to handle the new multi-step interactions and selection badges

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db347481e883209823bf96ba133573