### PR TITLE
Enhance publish modal with property details step

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6590,10 +6590,97 @@ body.profile-page {
     justify-content: flex-end;
 }
 
-.modal-publish__footer [data-publish-finish][disabled] {
+.modal-publish__footer [data-publish-continue][disabled] {
     opacity: 0.6;
     cursor: not-allowed;
     box-shadow: none;
+}
+
+.modal-publish__form {
+    margin-top: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.modal-publish__form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px 24px;
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.form-field--full {
+    grid-column: 1 / -1;
+}
+
+.form-field__label {
+    font-size: 15px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.form-field__sub-label {
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+    margin-bottom: 6px;
+}
+
+.form-field__input,
+.form-field__textarea {
+    width: 100%;
+    border: 1.5px solid #d1d5db;
+    border-radius: 12px;
+    padding: 12px 14px;
+    font-size: 15px;
+    color: #1f2937;
+    background-color: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field__input:focus,
+.form-field__textarea:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    outline: none;
+}
+
+.form-field__textarea {
+    resize: vertical;
+    min-height: 140px;
+}
+
+.form-field__hint {
+    font-size: 13px;
+    color: #6b7280;
+    margin-top: -4px;
+}
+
+.form-field__group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 16px;
+}
+
+.form-field__group:last-child {
+    margin-bottom: 0;
+}
+
+fieldset.form-field {
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+.modal-publish__form .modal-publish__footer {
+    margin-top: 12px;
 }
 
 @media (max-width: 600px) {
@@ -6606,6 +6693,10 @@ body.profile-page {
     }
 
     .modal-publish__options--grid {
+        grid-template-columns: 1fr;
+    }
+
+    .modal-publish__form-grid {
         grid-template-columns: 1fr;
     }
 }

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -21,8 +21,9 @@ document.addEventListener('DOMContentLoaded', () => {
         };
         const purposeOptions = Array.from(modal.querySelectorAll('[data-purpose]'));
         const typeOptions = Array.from(modal.querySelectorAll('[data-type]'));
-        const backButton = modal.querySelector('[data-publish-back]');
-        const finishButton = modal.querySelector('[data-publish-finish]');
+        const backButtons = Array.from(modal.querySelectorAll('[data-publish-back]'));
+        const continueButton = modal.querySelector('[data-publish-continue]');
+        const publishForm = modal.querySelector('[data-publish-form]');
 
         let publishState = {
             purpose: null,
@@ -65,8 +66,11 @@ document.addEventListener('DOMContentLoaded', () => {
             toggleOptionSelection(typeOptions, null);
             setBadge(summaryBadges.purpose, '');
             setBadge(summaryBadges.type, '');
-            if (finishButton) {
-                finishButton.disabled = true;
+            if (continueButton) {
+                continueButton.disabled = true;
+            }
+            if (publishForm) {
+                publishForm.reset();
             }
             showStep('purpose');
         };
@@ -121,8 +125,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 publishState.type = null;
                 toggleOptionSelection(typeOptions, null);
                 setBadge(summaryBadges.type, '');
-                if (finishButton) {
-                    finishButton.disabled = true;
+                if (continueButton) {
+                    continueButton.disabled = true;
                 }
                 showStep('type');
             });
@@ -133,28 +137,56 @@ document.addEventListener('DOMContentLoaded', () => {
                 publishState.type = option.dataset.type || null;
                 toggleOptionSelection(typeOptions, option);
                 setBadge(summaryBadges.type, option.dataset.label || '');
-                if (finishButton) {
-                    finishButton.disabled = false;
+                if (continueButton) {
+                    continueButton.disabled = false;
                 }
             });
         });
 
-        if (backButton) {
-            backButton.addEventListener('click', event => {
+        backButtons.forEach(button => {
+            button.addEventListener('click', event => {
                 event.preventDefault();
-                showStep('purpose');
-                if (finishButton) {
-                    finishButton.disabled = !publishState.type;
+                const target = button.dataset.publishBack;
+                if (!target) {
+                    return;
                 }
+                showStep(target);
+                if (continueButton) {
+                    if (target === 'type') {
+                        continueButton.disabled = !publishState.type;
+                    }
+                    if (target === 'purpose') {
+                        continueButton.disabled = true;
+                    }
+                }
+            });
+        });
+
+        if (continueButton) {
+            continueButton.addEventListener('click', event => {
+                event.preventDefault();
+                if (continueButton.disabled) {
+                    return;
+                }
+                showStep('details');
             });
         }
 
-        if (finishButton) {
-            finishButton.addEventListener('click', event => {
+        if (publishForm) {
+            publishForm.addEventListener('submit', event => {
                 event.preventDefault();
-                if (finishButton.disabled) {
-                    return;
-                }
+                const formData = new FormData(publishForm);
+                const details = {
+                    title: formData.get('title'),
+                    description: formData.get('description'),
+                    city: formData.get('city'),
+                    neighborhood: formData.get('neighborhood'),
+                    address: formData.get('address')
+                };
+                console.info('Información lista para publicar:', {
+                    ...publishState,
+                    details
+                });
                 closeModal();
             });
         }

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -73,7 +73,7 @@
         </div>
 
         <div class="modal-publish__step" data-step="type" role="group" aria-labelledby="publish-type-title">
-            <button type="button" class="modal-publish__back" data-publish-back>
+            <button type="button" class="modal-publish__back" data-publish-back="purpose">
                 <span aria-hidden="true">&#8592;</span>
                 Volver
             </button>
@@ -122,10 +122,56 @@
                 </button>
             </div>
             <footer class="modal-publish__footer">
-                <button type="button" class="dashboard__action-btn dashboard__action-btn--primary" data-publish-finish disabled>
+                <button type="button" class="dashboard__action-btn dashboard__action-btn--primary" data-publish-continue disabled>
                     Continuar con la publicación
                 </button>
             </footer>
+        </div>
+
+        <div class="modal-publish__step" data-step="details" role="group" aria-labelledby="publish-details-title">
+            <button type="button" class="modal-publish__back" data-publish-back="type">
+                <span aria-hidden="true">&#8592;</span>
+                Volver
+            </button>
+            <h2 class="modal__title" id="publish-details-title">Información de la propiedad</h2>
+            <p class="modal__subtitle">Completa los detalles principales para preparar tu anuncio profesional.</p>
+            <form class="modal-publish__form" data-publish-form>
+                <div class="modal-publish__form-grid">
+                    <div class="form-field">
+                        <label class="form-field__label" for="publish-title">Título del anuncio</label>
+                        <input class="form-field__input" type="text" id="publish-title" name="title" placeholder="Ej. Residencia contemporánea en zona exclusiva" required>
+                    </div>
+                    <div class="form-field form-field--full">
+                        <label class="form-field__label" for="publish-description">Descripción</label>
+                        <textarea class="form-field__textarea" id="publish-description" name="description" rows="4" placeholder="Describe los espacios, amenidades y beneficios clave." required></textarea>
+                    </div>
+                    <div class="form-field form-field--full">
+                        <label class="form-field__label" for="publish-images">Imágenes destacadas</label>
+                        <input class="form-field__input" type="file" id="publish-images" name="images" accept="image/*" multiple>
+                        <p class="form-field__hint">Agrega fotografías en alta resolución (JPG o PNG). Puedes seleccionar varias a la vez.</p>
+                    </div>
+                    <fieldset class="form-field form-field--full">
+                        <legend class="form-field__label">Ubicación</legend>
+                        <div class="form-field__group">
+                            <label class="form-field__sub-label" for="publish-location-city">Ciudad</label>
+                            <input class="form-field__input" type="text" id="publish-location-city" name="city" placeholder="Cancún" required>
+                        </div>
+                        <div class="form-field__group">
+                            <label class="form-field__sub-label" for="publish-location-neighborhood">Colonia o fraccionamiento</label>
+                            <input class="form-field__input" type="text" id="publish-location-neighborhood" name="neighborhood" placeholder="Puerto Cancún" required>
+                        </div>
+                        <div class="form-field__group">
+                            <label class="form-field__sub-label" for="publish-location-address">Dirección (opcional)</label>
+                            <input class="form-field__input" type="text" id="publish-location-address" name="address" placeholder="Av. Bonampak 125, Torre Norte">
+                        </div>
+                    </fieldset>
+                </div>
+                <footer class="modal-publish__footer">
+                    <button type="submit" class="dashboard__action-btn dashboard__action-btn--primary" data-publish-submit>
+                        Guardar y continuar más tarde
+                    </button>
+                </footer>
+            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add a details step to the publish modal so users can capture title, description, images, and location information
- extend the publish modal script to handle the new step navigation and form submission flow
- style the new form inputs to match the dashboard visual language

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68db3c52a14c832086fe0d32c5b95eec