### PR TITLE
Add property details form step to publish modal

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6590,10 +6590,129 @@ body.profile-page {
     justify-content: flex-end;
 }
 
-.modal-publish__footer [data-publish-finish][disabled] {
+.modal-publish__footer [data-publish-finish][disabled],
+.modal-publish__footer [data-publish-continue][disabled] {
     opacity: 0.6;
     cursor: not-allowed;
     box-shadow: none;
+}
+
+.modal-publish__form {
+    display: grid;
+    gap: 24px;
+    margin-top: 28px;
+}
+
+.modal-publish__field {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.modal-publish__label {
+    font-size: 15px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.modal-publish__input,
+.modal-publish__textarea {
+    width: 100%;
+    border: 1.5px solid #d1d5db;
+    border-radius: 12px;
+    padding: 14px 16px;
+    font-size: 15px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background: #ffffff;
+    color: #111827;
+}
+
+.modal-publish__input:focus,
+.modal-publish__textarea:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.modal-publish__textarea {
+    min-height: 140px;
+    resize: vertical;
+    line-height: 1.6;
+}
+
+.modal-publish__hint {
+    font-size: 13px;
+    color: #6b7280;
+}
+
+.modal-publish__upload {
+    border: 2px dashed #bfdbfe;
+    border-radius: 16px;
+    background: #f8fafc;
+    padding: 24px;
+    display: grid;
+    justify-items: center;
+    gap: 12px;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    text-align: center;
+}
+
+.modal-publish__upload:focus,
+.modal-publish__upload:hover {
+    border-color: #2563eb;
+    background: #eff6ff;
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.12);
+    outline: none;
+}
+
+.modal-publish__upload-input {
+    display: none;
+}
+
+.modal-publish__upload-icon {
+    font-size: 28px;
+}
+
+.modal-publish__upload-text {
+    font-size: 14px;
+    color: #1f2937;
+}
+
+.modal-publish__upload-text span {
+    color: #2563eb;
+    font-weight: 600;
+}
+
+.modal-publish__upload-note {
+    font-size: 12px;
+    color: #6b7280;
+}
+
+.modal-publish__input-wrapper {
+    position: relative;
+}
+
+.modal-publish__input-icon {
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 18px;
+    color: #2563eb;
+}
+
+.modal-publish__input-wrapper .modal-publish__input {
+    padding-left: 44px;
+}
+
+.modal-publish__footer--end {
+    padding-top: 8px;
+    border-top: 1px solid #e5e7eb;
+}
+
+.modal-publish__footer--end .dashboard__action-btn {
+    min-width: 210px;
 }
 
 @media (max-width: 600px) {
@@ -6607,6 +6726,11 @@ body.profile-page {
 
     .modal-publish__options--grid {
         grid-template-columns: 1fr;
+    }
+
+    .modal-publish__form {
+        margin-top: 20px;
+        gap: 20px;
     }
 }
 

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -17,16 +17,21 @@ document.addEventListener('DOMContentLoaded', () => {
         const steps = Array.from(modal.querySelectorAll('.modal-publish__step'));
         const summaryBadges = {
             purpose: modal.querySelector('[data-selection-purpose]'),
-            type: modal.querySelector('[data-selection-type]')
+            type: modal.querySelector('[data-selection-type]'),
+            title: modal.querySelector('[data-selection-title]')
         };
         const purposeOptions = Array.from(modal.querySelectorAll('[data-purpose]'));
         const typeOptions = Array.from(modal.querySelectorAll('[data-type]'));
-        const backButton = modal.querySelector('[data-publish-back]');
+        const backButtons = Array.from(modal.querySelectorAll('[data-publish-back]'));
+        const continueButton = modal.querySelector('[data-publish-continue]');
         const finishButton = modal.querySelector('[data-publish-finish]');
+        const detailsForm = modal.querySelector('[data-publish-form]');
+        const firstDetailField = detailsForm ? detailsForm.querySelector('input, textarea') : null;
 
         let publishState = {
             purpose: null,
-            type: null
+            type: null,
+            title: ''
         };
 
         const setBadge = (badge, label) => {
@@ -60,13 +65,20 @@ document.addEventListener('DOMContentLoaded', () => {
         };
 
         const resetPublishState = () => {
-            publishState = { purpose: null, type: null };
+            publishState = { purpose: null, type: null, title: '' };
             toggleOptionSelection(purposeOptions, null);
             toggleOptionSelection(typeOptions, null);
             setBadge(summaryBadges.purpose, '');
             setBadge(summaryBadges.type, '');
+            setBadge(summaryBadges.title, '');
+            if (continueButton) {
+                continueButton.disabled = true;
+            }
             if (finishButton) {
                 finishButton.disabled = true;
+            }
+            if (detailsForm) {
+                detailsForm.reset();
             }
             showStep('purpose');
         };
@@ -121,8 +133,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 publishState.type = null;
                 toggleOptionSelection(typeOptions, null);
                 setBadge(summaryBadges.type, '');
+                setBadge(summaryBadges.title, '');
+                publishState.title = '';
                 if (finishButton) {
                     finishButton.disabled = true;
+                }
+                if (continueButton) {
+                    continueButton.disabled = true;
+                }
+                if (detailsForm) {
+                    detailsForm.reset();
                 }
                 showStep('type');
             });
@@ -133,26 +153,74 @@ document.addEventListener('DOMContentLoaded', () => {
                 publishState.type = option.dataset.type || null;
                 toggleOptionSelection(typeOptions, option);
                 setBadge(summaryBadges.type, option.dataset.label || '');
-                if (finishButton) {
-                    finishButton.disabled = false;
+                if (continueButton) {
+                    continueButton.disabled = false;
                 }
             });
         });
 
-        if (backButton) {
-            backButton.addEventListener('click', event => {
+        const updateFinishState = () => {
+            if (!finishButton || !detailsForm) {
+                return;
+            }
+            finishButton.disabled = !detailsForm.checkValidity();
+        };
+
+        if (detailsForm) {
+            detailsForm.addEventListener('input', updateFinishState);
+            detailsForm.addEventListener('change', updateFinishState);
+        }
+
+        if (continueButton) {
+            continueButton.addEventListener('click', event => {
                 event.preventDefault();
-                showStep('purpose');
-                if (finishButton) {
-                    finishButton.disabled = !publishState.type;
+                if (continueButton.disabled) {
+                    return;
+                }
+                showStep('details');
+                if (firstDetailField) {
+                    firstDetailField.focus();
+                }
+                updateFinishState();
+            });
+        }
+
+        backButtons.forEach(button => {
+            button.addEventListener('click', event => {
+                event.preventDefault();
+                const targetStep = button.dataset.publishBack || 'purpose';
+                showStep(targetStep);
+                if (targetStep === 'purpose') {
+                    if (continueButton) {
+                        continueButton.disabled = true;
+                    }
+                    if (finishButton) {
+                        finishButton.disabled = true;
+                    }
+                }
+                if (targetStep === 'type' && continueButton) {
+                    continueButton.disabled = !publishState.type;
                 }
             });
+        });
+
+        const titleInput = detailsForm ? detailsForm.querySelector('[name="property-title"]') : null;
+        if (titleInput) {
+            const handleTitleUpdate = () => {
+                publishState.title = titleInput.value.trim();
+                setBadge(summaryBadges.title, publishState.title);
+            };
+            titleInput.addEventListener('input', handleTitleUpdate);
+            titleInput.addEventListener('change', handleTitleUpdate);
         }
 
         if (finishButton) {
             finishButton.addEventListener('click', event => {
                 event.preventDefault();
                 if (finishButton.disabled) {
+                    return;
+                }
+                if (detailsForm && !detailsForm.reportValidity()) {
                     return;
                 }
                 closeModal();

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -39,6 +39,7 @@
         <div class="modal-publish__summary" aria-live="polite">
             <span class="modal-publish__badge" data-selection-purpose hidden></span>
             <span class="modal-publish__badge" data-selection-type hidden></span>
+            <span class="modal-publish__badge" data-selection-title hidden></span>
         </div>
 
         <div class="modal-publish__step modal-publish__step--active" data-step="purpose" role="group" aria-labelledby="publish-purpose-title">
@@ -73,7 +74,7 @@
         </div>
 
         <div class="modal-publish__step" data-step="type" role="group" aria-labelledby="publish-type-title">
-            <button type="button" class="modal-publish__back" data-publish-back>
+            <button type="button" class="modal-publish__back" data-publish-back="purpose">
                 <span aria-hidden="true">&#8592;</span>
                 Volver
             </button>
@@ -122,10 +123,60 @@
                 </button>
             </div>
             <footer class="modal-publish__footer">
-                <button type="button" class="dashboard__action-btn dashboard__action-btn--primary" data-publish-finish disabled>
+                <button type="button" class="dashboard__action-btn dashboard__action-btn--primary" data-publish-continue disabled>
                     Continuar con la publicación
                 </button>
             </footer>
+        </div>
+
+        <div class="modal-publish__step" data-step="details" role="group" aria-labelledby="publish-details-title">
+            <button type="button" class="modal-publish__back" data-publish-back="type">
+                <span aria-hidden="true">&#8592;</span>
+                Volver
+            </button>
+            <h2 class="modal__title" id="publish-details-title">Personaliza tu anuncio</h2>
+            <p class="modal__subtitle">Completa la información esencial para presentar tu propiedad de forma profesional.</p>
+
+            <form class="modal-publish__form" data-publish-form>
+                <div class="modal-publish__field">
+                    <label for="publish-title" class="modal-publish__label">Título del anuncio</label>
+                    <input type="text" id="publish-title" name="property-title" class="modal-publish__input" placeholder="Ej. Casa moderna con terraza en Lomas del Valle" required maxlength="120">
+                    <p class="modal-publish__hint">Utiliza un título conciso que destaque el principal atractivo del inmueble.</p>
+                </div>
+
+                <div class="modal-publish__field">
+                    <label for="publish-description" class="modal-publish__label">Descripción</label>
+                    <textarea id="publish-description" name="property-description" class="modal-publish__textarea" placeholder="Describe distribución, amenidades, acabados y beneficios de la zona." rows="5" required></textarea>
+                    <p class="modal-publish__hint">Incluye información relevante como metros cuadrados, número de habitaciones y servicios cercanos.</p>
+                </div>
+
+                <div class="modal-publish__field">
+                    <span class="modal-publish__label">Galería de imágenes</span>
+                    <label for="publish-images" class="modal-publish__upload" tabindex="0">
+                        <input type="file" id="publish-images" name="property-images" class="modal-publish__upload-input" accept="image/*" multiple>
+                        <span class="modal-publish__upload-icon" aria-hidden="true">📁</span>
+                        <span class="modal-publish__upload-text">
+                            Arrastra y suelta tus fotografías o <span>haz clic para seleccionarlas</span>
+                        </span>
+                        <span class="modal-publish__upload-note">Formatos JPG o PNG. Recomendado: mínimo 1200px por lado.</span>
+                    </label>
+                </div>
+
+                <div class="modal-publish__field">
+                    <label for="publish-location" class="modal-publish__label">Ubicación</label>
+                    <div class="modal-publish__input-wrapper">
+                        <span class="modal-publish__input-icon" aria-hidden="true">📍</span>
+                        <input type="text" id="publish-location" name="property-location" class="modal-publish__input" placeholder="Ingresa colonia, ciudad o dirección aproximada" required>
+                    </div>
+                    <p class="modal-publish__hint">Comparte una ubicación referencial para ayudar a tus clientes a identificar la zona.</p>
+                </div>
+
+                <footer class="modal-publish__footer modal-publish__footer--end">
+                    <button type="submit" class="dashboard__action-btn dashboard__action-btn--primary" data-publish-finish disabled>
+                        Guardar y continuar
+                    </button>
+                </footer>
+            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add a dedicated "Personaliza tu anuncio" step in the publish modal with fields for título, descripción, imágenes y ubicación
- style the new detail fields, upload area, and footer actions to match the dashboard aesthetic
- extend the modal script to manage the new step flow, badges, and validation before finishing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db457ccf008320b891c36fab46ce45