### PR TITLE
Add professional publish details modal

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6596,6 +6596,226 @@ body.profile-page {
     box-shadow: none;
 }
 
+.modal-publish-details {
+    max-width: 720px;
+    padding: 48px 56px;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    background: linear-gradient(165deg, #ffffff 60%, rgba(219, 234, 254, 0.5));
+}
+
+.modal-publish-details__header {
+    display: grid;
+    gap: 8px;
+}
+
+.modal-publish-details__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #1d4ed8;
+    background: rgba(59, 130, 246, 0.12);
+}
+
+.publish-details {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.publish-details__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px;
+}
+
+.publish-details__field {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.publish-details__field label {
+    font-weight: 600;
+    color: #1f2937;
+    font-size: 15px;
+}
+
+.publish-details__field input,
+.publish-details__field textarea {
+    width: 100%;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding: 14px 16px;
+    font-size: 15px;
+    line-height: 1.5;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.publish-details__field input:focus,
+.publish-details__field textarea:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.publish-details__field textarea {
+    resize: vertical;
+    min-height: 140px;
+}
+
+.publish-details__hint {
+    font-size: 13px;
+    color: #64748b;
+}
+
+.publish-details__location {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.publish-details__location input {
+    padding-right: 52px;
+}
+
+.publish-details__location-btn {
+    position: absolute;
+    right: 12px;
+    border: none;
+    background: #2563eb;
+    color: #ffffff;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.publish-details__location-btn:hover,
+.publish-details__location-btn:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 25px rgba(37, 99, 235, 0.3);
+}
+
+.publish-details__location-btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.publish-details__upload {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 28px;
+    align-items: center;
+    padding: 28px;
+    border: 1px dashed rgba(148, 163, 184, 0.5);
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(239, 246, 255, 0.6), rgba(219, 234, 254, 0.4));
+    cursor: pointer;
+}
+
+.publish-details__file-input {
+    display: none;
+}
+
+.publish-details__upload-illustration svg {
+    width: 96px;
+    height: 96px;
+}
+
+.publish-details__upload-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    color: #1f2937;
+    font-size: 15px;
+}
+
+.publish-details__upload-copy strong {
+    font-size: 16px;
+}
+
+.publish-details__upload-copy span {
+    color: #64748b;
+    font-size: 13px;
+}
+
+.publish-details__upload-btn {
+    align-self: flex-start;
+    margin-top: 6px;
+    padding: 10px 18px;
+    border-radius: 12px;
+    border: none;
+    background: #2563eb;
+    color: #ffffff;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.publish-details__upload-btn:hover,
+.publish-details__upload-btn:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 30px rgba(37, 99, 235, 0.3);
+}
+
+.publish-details__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+}
+
+.publish-details__actions .modal__action {
+    padding: 12px 22px;
+    border: none;
+    color: #1f2937;
+    background: rgba(226, 232, 240, 0.7);
+    font-weight: 600;
+}
+
+.publish-details__actions .modal__action:hover,
+.publish-details__actions .modal__action:focus {
+    background: rgba(203, 213, 225, 0.9);
+}
+
+@media (max-width: 900px) {
+    .modal-publish-details {
+        padding: 40px 28px;
+        max-width: 90vw;
+    }
+
+    .publish-details__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .publish-details__upload {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    .publish-details__upload-copy {
+        align-items: center;
+    }
+
+    .publish-details__upload-btn {
+        align-self: center;
+    }
+}
+
 @media (max-width: 600px) {
     .modal__dialog {
         padding: 32px 24px;

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -23,6 +23,83 @@ document.addEventListener('DOMContentLoaded', () => {
         const typeOptions = Array.from(modal.querySelectorAll('[data-type]'));
         const backButton = modal.querySelector('[data-publish-back]');
         const finishButton = modal.querySelector('[data-publish-finish]');
+        const detailsModal = panel.querySelector('[data-modal="publish-details"]');
+
+        const createModalController = (modalElement) => {
+            if (!modalElement) {
+                return null;
+            }
+
+            const closers = Array.from(modalElement.querySelectorAll('[data-modal-close]'));
+            const firstField = modalElement.querySelector('input, textarea, select, button');
+
+            const updateAriaState = (isOpen) => {
+                modalElement.setAttribute('aria-hidden', String(!isOpen));
+                if (isOpen) {
+                    modalElement.setAttribute('aria-modal', 'true');
+                } else {
+                    modalElement.removeAttribute('aria-modal');
+                }
+            };
+
+            const handleKeyDown = (event) => {
+                if (event.key === 'Escape') {
+                    close();
+                }
+            };
+
+            const close = () => {
+                modalElement.classList.remove('modal--visible');
+                updateAriaState(false);
+                document.removeEventListener('keydown', handleKeyDown);
+            };
+
+            const open = () => {
+                modalElement.classList.add('modal--visible');
+                updateAriaState(true);
+                document.addEventListener('keydown', handleKeyDown);
+                if (firstField) {
+                    setTimeout(() => firstField.focus(), 50);
+                }
+            };
+
+            closers.forEach(closer => {
+                closer.addEventListener('click', event => {
+                    event.preventDefault();
+                    close();
+                });
+            });
+
+            const fileInput = modalElement.querySelector('.publish-details__file-input');
+            const uploadButton = modalElement.querySelector('.publish-details__upload-btn');
+            const uploadArea = modalElement.querySelector('.publish-details__upload');
+
+            const triggerFileDialog = () => {
+                if (fileInput) {
+                    fileInput.click();
+                }
+            };
+
+            if (uploadButton && fileInput) {
+                uploadButton.addEventListener('click', event => {
+                    event.preventDefault();
+                    triggerFileDialog();
+                });
+            }
+
+            if (uploadArea && fileInput) {
+                uploadArea.addEventListener('click', event => {
+                    if (event.target.closest('button') || event.target === fileInput) {
+                        return;
+                    }
+                    triggerFileDialog();
+                });
+            }
+
+            return { open, close };
+        };
+
+        const detailsModalController = createModalController(detailsModal);
 
         let publishState = {
             purpose: null,
@@ -156,6 +233,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     return;
                 }
                 closeModal();
+                if (detailsModalController) {
+                    detailsModalController.open();
+                }
             });
         }
     };

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -129,3 +129,66 @@
         </div>
     </div>
 </div>
+
+<div class="modal" data-modal="publish-details" aria-hidden="true" role="dialog">
+    <div class="modal__overlay" data-modal-close></div>
+    <div class="modal__dialog modal-publish-details" role="document">
+        <button class="modal__close" type="button" aria-label="Cerrar" data-modal-close>&times;</button>
+        <header class="modal-publish-details__header">
+            <span class="modal-publish-details__badge">Ficha profesional</span>
+            <h2 class="modal__title">Comparte los detalles clave</h2>
+            <p class="modal__subtitle">Completa la información esencial para que tu propiedad destaque.</p>
+        </header>
+        <form class="publish-details" novalidate>
+            <div class="publish-details__grid">
+                <div class="publish-details__field">
+                    <label for="publish-title">Título del anuncio</label>
+                    <input type="text" id="publish-title" name="title" placeholder="Ej. Residencia moderna en Puerto Cancún" required>
+                    <span class="publish-details__hint">Usa un título atractivo que resalte el valor principal.</span>
+                </div>
+                <div class="publish-details__field">
+                    <label for="publish-location">Ubicación</label>
+                    <div class="publish-details__location">
+                        <input type="text" id="publish-location" name="location" placeholder="Ciudad, colonia o desarrollo" required>
+                        <button type="button" class="publish-details__location-btn" aria-label="Localizar en mapa">
+                            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                <path d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7Zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Z" fill="currentColor"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <span class="publish-details__hint">Comparte la zona o punto de referencia más conocido.</span>
+                </div>
+            </div>
+
+            <div class="publish-details__field">
+                <label for="publish-description">Descripción destacada</label>
+                <textarea id="publish-description" name="description" rows="5" placeholder="Describe amenidades, distribución, acabados y cualquier detalle relevante." required></textarea>
+                <span class="publish-details__hint">Incluye los diferenciales de la propiedad y detalles que inspiren confianza.</span>
+            </div>
+
+            <div class="publish-details__field">
+                <label for="publish-images">Galería fotográfica</label>
+                <div class="publish-details__upload" role="group" aria-labelledby="publish-images">
+                    <input type="file" id="publish-images" name="images" accept="image/*" multiple class="publish-details__file-input" hidden>
+                    <div class="publish-details__upload-illustration" aria-hidden="true">
+                        <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                            <rect x="8" y="12" width="48" height="40" rx="10" fill="rgba(59,130,246,0.1)"/>
+                            <path d="M16 36l8-10 10 13 6-7 8 10" fill="none" stroke="#3b82f6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+                            <circle cx="24" cy="24" r="4" fill="#3b82f6"/>
+                        </svg>
+                    </div>
+                    <div class="publish-details__upload-copy">
+                        <strong>Arrastra y suelta tus imágenes</strong>
+                        <span>Admite JPG, PNG o WebP. Peso recomendado: &lt; 5MB por archivo.</span>
+                        <button type="button" class="publish-details__upload-btn">Seleccionar archivos</button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="publish-details__actions">
+                <button type="button" class="modal__action" data-modal-close>Completar más tarde</button>
+                <button type="submit" class="dashboard__action-btn dashboard__action-btn--primary">Guardar y continuar</button>
+            </div>
+        </form>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add a follow-up "Ficha profesional" modal to the propiedades template with title, description, image upload and location fields
- style the new modal to match the dashboard aesthetics and provide responsive tweaks
- update the publish flow script to open the details modal and support the custom upload trigger

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd6a74f9c88320ac69aa45e8668206