### PR TITLE
Revamp gallery preview presentation

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6816,20 +6816,151 @@ body.profile-page {
     box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
 }
 
-.publish-details__gallery-placeholder {
+.publish-details__gallery-status {
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 0.35rem;
-    text-align: center;
-    color: #475569;
-    font-size: 0.9rem;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1rem 1.25rem;
+    border-radius: 14px;
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.04));
+    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.12);
+    margin-bottom: 1.25rem;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
 }
 
-.publish-details__gallery-placeholder strong {
+.publish-details__gallery-status[data-state="filled"] {
+    border-color: rgba(37, 99, 235, 0.35);
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(59, 130, 246, 0.08));
+    box-shadow: 0 16px 32px rgba(37, 99, 235, 0.16);
+}
+
+.publish-details__gallery-status[data-state="complete"] {
+    border-color: rgba(34, 197, 94, 0.45);
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.18), rgba(134, 239, 172, 0.18));
+    box-shadow: 0 18px 34px rgba(16, 185, 129, 0.22);
+}
+
+.publish-details__gallery-status-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: #1e293b;
+}
+
+.publish-details__gallery-count {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.publish-details__gallery-count strong {
+    font-size: 1.1rem;
+    color: #1d4ed8;
+    margin-right: 0.35rem;
+}
+
+.publish-details__gallery-status[data-state="complete"] .publish-details__gallery-count strong {
+    color: #15803d;
+}
+
+.publish-details__gallery-note {
+    font-size: 0.82rem;
+    color: #475569;
+}
+
+.publish-details__gallery-progress {
+    min-width: 190px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.45rem;
+}
+
+.publish-details__gallery-progress-track {
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.3);
+    overflow: hidden;
+}
+
+.publish-details__gallery-progress-bar {
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, #2563eb, #3b82f6);
+    border-radius: 999px;
+    transition: width 0.35s ease;
+}
+
+.publish-details__gallery-status[data-state="complete"] .publish-details__gallery-progress-bar {
+    background: linear-gradient(90deg, #16a34a, #22c55e);
+}
+
+.publish-details__gallery-progress-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #1d4ed8;
+}
+
+.publish-details__gallery-status[data-state="complete"] .publish-details__gallery-progress-label {
+    color: #15803d;
+}
+
+.publish-details__gallery-placeholder {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 1.25rem;
+    text-align: left;
+    color: #475569;
+    font-size: 0.9rem;
+    padding: 1.25rem;
+    border-radius: 14px;
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+    background: linear-gradient(135deg, rgba(226, 232, 240, 0.6), rgba(241, 245, 249, 0.9));
+}
+
+.publish-details__gallery-placeholder-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    border-radius: 18px;
+    background: rgba(37, 99, 235, 0.12);
+    color: #2563eb;
+}
+
+.publish-details__gallery-placeholder-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.publish-details__gallery-placeholder-copy strong {
     font-weight: 600;
     color: #1e293b;
+    font-size: 1rem;
+}
+
+.publish-details__gallery-placeholder-copy p {
+    margin: 0;
+    color: #475569;
+    font-size: 0.85rem;
+    line-height: 1.6;
+}
+
+.publish-details__gallery-tips {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: #475569;
+    list-style: disc;
 }
 
 .publish-details__gallery-list {
@@ -6851,6 +6982,10 @@ body.profile-page {
 
 .publish-details__gallery:not([data-empty="true"]) .publish-details__gallery-placeholder {
     display: none;
+}
+
+.publish-details__gallery[data-empty="true"] .publish-details__gallery-status {
+    box-shadow: 0 8px 18px rgba(148, 163, 184, 0.25);
 }
 
 .publish-details__gallery-item {
@@ -6960,6 +7095,18 @@ body.profile-page {
 .publish-details__gallery-remove:focus {
     background: rgba(239, 68, 68, 0.16);
     color: #dc2626;
+}
+
+@media (max-width: 768px) {
+    .publish-details__gallery-status {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .publish-details__gallery-progress {
+        width: 100%;
+        align-items: flex-start;
+    }
 }
 
 .publish-details__actions {

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -37,7 +37,14 @@ document.addEventListener('DOMContentLoaded', () => {
             const uploadArea = modalElement.querySelector('.publish-details__upload');
             const galleryContainer = modalElement.querySelector('.publish-details__gallery');
             const galleryList = modalElement.querySelector('[data-gallery-list]');
+            const galleryStatus = modalElement.querySelector('[data-gallery-status]');
+            const galleryCount = modalElement.querySelector('[data-gallery-count]');
+            const galleryProgress = modalElement.querySelector('[data-gallery-progress]');
+            const galleryProgressWrapper = modalElement.querySelector('[data-gallery-progress-wrapper]');
+            const galleryProgressLabel = modalElement.querySelector('[data-gallery-progress-label]');
+            const galleryCover = modalElement.querySelector('[data-gallery-cover]');
             const galleryItems = [];
+            const recommendedGallerySize = 12;
             let dragSourceIndex = null;
 
             const updateAriaState = (isOpen) => {
@@ -111,7 +118,45 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (!galleryContainer) {
                     return;
                 }
-                galleryContainer.dataset.empty = galleryItems.length ? 'false' : 'true';
+
+                const count = galleryItems.length;
+                const isEmpty = count === 0;
+                const percentage = Math.min(Math.round((count / recommendedGallerySize) * 100), 100);
+                const statusState = isEmpty ? 'empty' : (count >= recommendedGallerySize ? 'complete' : 'filled');
+
+                galleryContainer.dataset.empty = isEmpty ? 'true' : 'false';
+
+                if (galleryStatus) {
+                    galleryStatus.dataset.state = statusState;
+                }
+
+                if (galleryCount) {
+                    galleryCount.textContent = String(count);
+                }
+
+                if (galleryCover) {
+                    galleryCover.textContent = isEmpty
+                        ? 'La portada se asignará a la primera imagen que cargues.'
+                        : `Portada actual: ${formatFileName(galleryItems[0].file.name)}`;
+                }
+
+                if (galleryProgress) {
+                    galleryProgress.style.width = `${percentage}%`;
+                    galleryProgress.setAttribute('data-progress-value', String(percentage));
+                }
+
+                if (galleryProgressLabel) {
+                    galleryProgressLabel.textContent = count >= recommendedGallerySize
+                        ? 'Galería lista'
+                        : `${count}/${recommendedGallerySize} sugeridas`;
+                }
+
+                if (galleryProgressWrapper) {
+                    const label = statusState === 'complete'
+                        ? 'Progreso de la galería completado'
+                        : `Progreso de la galería ${percentage}% listo`;
+                    galleryProgressWrapper.setAttribute('aria-label', label);
+                }
             };
 
             const removeGalleryItem = (index) => {

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -184,9 +184,35 @@
                     </div>
                 </div>
                 <div class="publish-details__gallery" aria-live="polite" data-empty="true">
+                    <div class="publish-details__gallery-status" data-gallery-status data-state="empty">
+                        <div class="publish-details__gallery-status-main">
+                            <span class="publish-details__gallery-count"><strong data-gallery-count>0</strong> imágenes cargadas</span>
+                            <span class="publish-details__gallery-note" data-gallery-cover>La portada se asignará a la primera imagen que cargues.</span>
+                        </div>
+                        <div class="publish-details__gallery-progress" data-gallery-progress-wrapper role="img" aria-label="Progreso de la galería 0% listo">
+                            <div class="publish-details__gallery-progress-track">
+                                <div class="publish-details__gallery-progress-bar" data-gallery-progress style="width: 0%;"></div>
+                            </div>
+                            <span class="publish-details__gallery-progress-label" data-gallery-progress-label>0% listo</span>
+                        </div>
+                    </div>
                     <div class="publish-details__gallery-placeholder" data-gallery-placeholder>
-                        <strong>Aquí verás la vista previa de tu galería.</strong>
-                        <span>Organiza el orden arrastrando cada imagen. La primera será la portada de tu anuncio.</span>
+                        <span class="publish-details__gallery-placeholder-icon" aria-hidden="true">
+                            <svg viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                                <rect x="5" y="9" width="46" height="36" rx="10" fill="rgba(59,130,246,0.12)" />
+                                <path d="M16 32l7-9 8 11 5-6 6 7" fill="none" stroke="#2563eb" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" />
+                                <circle cx="21" cy="22" r="4" fill="#2563eb" fill-opacity="0.85" />
+                            </svg>
+                        </span>
+                        <div class="publish-details__gallery-placeholder-copy">
+                            <strong>Aquí verás la vista previa de tu galería.</strong>
+                            <p>Ordena las fotografías para narrar un recorrido atractivo: inicia con la fachada, continúa con las áreas sociales y finaliza con los detalles clave.</p>
+                            <ul class="publish-details__gallery-tips">
+                                <li>Utiliza imágenes horizontales en alta resolución y buena iluminación.</li>
+                                <li>Incluye al menos una foto por espacio destacado y amenidad relevante.</li>
+                                <li>Añade planos, renders o vistas aéreas si cuentas con ellos.</li>
+                            </ul>
+                        </div>
                     </div>
                     <ul class="publish-details__gallery-list" data-gallery-list></ul>
                 </div>


### PR DESCRIPTION
## Summary
- add a gallery status header with counters, cover info, and a progress indicator
- redesign the empty gallery placeholder with iconography and actionable tips
- extend modal scripting to keep the new status elements updated and accessible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddd671936883208f633799fb0b3b74