### PR TITLE
Ajusta footer de galería en modal de propiedades

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -7023,7 +7023,7 @@ body.profile-page {
     grid-template-rows: auto auto;
     align-items: center;
     column-gap: 0.75rem;
-    row-gap: 0.35rem;
+    row-gap: 0.25rem;
     padding: 0.65rem 0.85rem;
     background: rgba(15, 23, 42, 0.04);
     font-size: 0.8rem;
@@ -7035,11 +7035,10 @@ body.profile-page {
     min-width: 0;
     font-weight: 500;
     color: #1f2937;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
     grid-column: 2;
     grid-row: 1;
+    line-height: 1.3;
+    overflow-wrap: anywhere;
 }
 
 .publish-details__gallery-meta {
@@ -7064,29 +7063,6 @@ body.profile-page {
     grid-row: 1 / span 2;
 }
 
-.publish-details__gallery-actions {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    justify-self: end;
-    grid-row: 1 / span 2;
-    align-self: center;
-}
-
-.publish-details__gallery-handle {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.8rem;
-    height: 1.8rem;
-    border-radius: 999px;
-    border: 1px solid rgba(37, 99, 235, 0.35);
-    background: rgba(37, 99, 235, 0.08);
-    color: #1d4ed8;
-    font-size: 0.85rem;
-    pointer-events: none;
-}
-
 .publish-details__gallery-remove {
     display: inline-flex;
     align-items: center;
@@ -7099,6 +7075,8 @@ body.profile-page {
     color: #ef4444;
     font-size: 0.95rem;
     transition: background-color 0.2s ease, color 0.2s ease;
+    grid-row: 1 / span 2;
+    justify-self: end;
 }
 
 .publish-details__gallery-remove:hover,

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -240,14 +240,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     meta.className = 'publish-details__gallery-meta';
                     meta.textContent = formatFileSize(item.file.size);
 
-                    const actions = document.createElement('div');
-                    actions.className = 'publish-details__gallery-actions';
-
-                    const handleIcon = document.createElement('span');
-                    handleIcon.className = 'publish-details__gallery-handle';
-                    handleIcon.setAttribute('aria-hidden', 'true');
-                    handleIcon.innerHTML = '&#8942;';
-
                     const removeButton = document.createElement('button');
                     removeButton.type = 'button';
                     removeButton.className = 'publish-details__gallery-remove';
@@ -258,8 +250,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         removeGalleryItem(index);
                     });
 
-                    actions.append(handleIcon, removeButton);
-                    footer.append(indexBadge, name, meta, actions);
+                    footer.append(indexBadge, name, meta, removeButton);
                     listItem.append(image, footer);
 
                     listItem.addEventListener('dragstart', handleItemDragStart);


### PR DESCRIPTION
## Summary
- elimina el icono de arrastre en los elementos de la galería del modal de publicación y deja solo el botón de eliminar
- ajusta el layout del pie de la galería para que el índice y el botón de eliminar convivan sin recortar el nombre de la imagen
- permite que los nombres de archivo se muestren completos envolviéndose cuando sea necesario

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dec70ac8648320be72e74fb4935746