### PR TITLE
Ajusta footer de galería en modal de propiedades

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -7019,18 +7019,24 @@ body.profile-page {
 
 .publish-details__gallery-item footer {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    align-items: flex-start;
+    justify-content: flex-start;
     padding: 0.5rem 0.75rem;
     background: rgba(15, 23, 42, 0.04);
     font-size: 0.8rem;
     color: #1e293b;
-    gap: 0.5rem;
+    gap: 0.75rem;
+}
+
+.publish-details__gallery-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    flex: 1;
+    min-width: 0;
 }
 
 .publish-details__gallery-name {
-    flex: 1;
-    min-width: 0;
     font-weight: 500;
     color: #1f2937;
     white-space: nowrap;
@@ -7039,6 +7045,7 @@ body.profile-page {
 }
 
 .publish-details__gallery-meta {
+    display: block;
     font-size: 0.75rem;
     color: #64748b;
 }
@@ -7061,20 +7068,6 @@ body.profile-page {
     align-items: center;
     gap: 0.35rem;
     margin-left: auto;
-}
-
-.publish-details__gallery-handle {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.8rem;
-    height: 1.8rem;
-    border-radius: 999px;
-    border: 1px solid rgba(37, 99, 235, 0.35);
-    background: rgba(37, 99, 235, 0.08);
-    color: #1d4ed8;
-    font-size: 0.85rem;
-    pointer-events: none;
 }
 
 .publish-details__gallery-remove {

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -240,13 +240,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     meta.className = 'publish-details__gallery-meta';
                     meta.textContent = formatFileSize(item.file.size);
 
+                    const info = document.createElement('div');
+                    info.className = 'publish-details__gallery-info';
+                    info.append(name, meta);
+
                     const actions = document.createElement('div');
                     actions.className = 'publish-details__gallery-actions';
-
-                    const handleIcon = document.createElement('span');
-                    handleIcon.className = 'publish-details__gallery-handle';
-                    handleIcon.setAttribute('aria-hidden', 'true');
-                    handleIcon.innerHTML = '&#8942;';
 
                     const removeButton = document.createElement('button');
                     removeButton.type = 'button';
@@ -258,8 +257,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         removeGalleryItem(index);
                     });
 
-                    actions.append(handleIcon, removeButton);
-                    footer.append(indexBadge, name, meta, actions);
+                    actions.append(removeButton);
+                    footer.append(indexBadge, info, actions);
                     listItem.append(image, footer);
 
                     listItem.addEventListener('dragstart', handleItemDragStart);


### PR DESCRIPTION
## Summary
- reorganized the gallery footer in the publish modal to drop the drag handle and focus on the index and remove button
- updated the gallery layout styles so the filename and metadata stack compactly without enlarging the cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df34bcf6a083208421890c5bff3dcf