### PR TITLE
Improve property features modal layout

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -7128,6 +7128,40 @@ body.profile-page {
     gap: 12px;
 }
 
+.property-features__header-main {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.property-features__actions {
+    display: inline-flex;
+    gap: 10px;
+}
+
+.property-features__action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    background: #fff;
+    color: #0f172a;
+    font-size: 0.9rem;
+    font-weight: 600;
+    transition: all 0.2s ease;
+}
+
+.property-features__action-btn:hover,
+.property-features__action-btn:focus-visible {
+    border-color: rgba(37, 99, 235, 0.4);
+    color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
 .property-features__badge {
     display: inline-flex;
     align-items: center;
@@ -7189,6 +7223,31 @@ body.profile-page {
     font-size: 0.92rem;
 }
 
+.property-features__badge-group {
+    display: flex;
+    gap: 10px;
+    margin-left: auto;
+    flex-wrap: wrap;
+}
+
+.property-features__badge-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.12);
+    color: #1d4ed8;
+    font-weight: 600;
+    font-size: 0.78rem;
+    letter-spacing: 0.01em;
+}
+
+.property-features__badge-pill--secondary {
+    background: rgba(14, 165, 233, 0.12);
+    color: #0e7490;
+}
+
 .property-features__empty {
     display: flex;
     flex-direction: column;
@@ -7217,6 +7276,119 @@ body.profile-page {
     display: flex;
     flex-direction: column;
     gap: 28px;
+}
+
+.property-features__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+    gap: 32px;
+    align-items: start;
+}
+
+@media (max-width: 1100px) {
+    .property-features__layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+.property-features__primary {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.property-features__toolbar {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    padding: 24px;
+    border-radius: 18px;
+    border: 1px solid rgba(203, 213, 225, 0.6);
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.06), rgba(59, 130, 246, 0.02));
+}
+
+.property-features__search-label {
+    font-weight: 600;
+    color: #0f172a;
+    font-size: 0.95rem;
+}
+
+.property-features__search {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.property-features__search-icon {
+    position: absolute;
+    inset-inline-start: 16px;
+    color: #64748b;
+    width: 18px;
+    height: 18px;
+}
+
+.property-features__search-input {
+    width: 100%;
+    padding: 12px 120px 12px 44px;
+    border-radius: 12px;
+    border: 1.4px solid rgba(148, 163, 184, 0.45);
+    background: #fff;
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.property-features__search-input:focus {
+    outline: none;
+    border-color: rgba(37, 99, 235, 0.6);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.property-features__search-clear {
+    position: absolute;
+    inset-inline-end: 16px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: none;
+    background: rgba(15, 23, 42, 0.08);
+    color: #0f172a;
+    font-weight: 600;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.property-features__search-clear:hover,
+.property-features__search-clear:focus-visible {
+    background: rgba(37, 99, 235, 0.16);
+    color: #1d4ed8;
+}
+
+.property-features__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.property-features__chip {
+    padding: 6px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: #fff;
+    color: #475569;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.property-features__chip:hover,
+.property-features__chip:focus-visible,
+.property-features__chip.is-active {
+    border-color: rgba(37, 99, 235, 0.45);
+    background: rgba(37, 99, 235, 0.08);
+    color: #2563eb;
+    box-shadow: 0 8px 20px rgba(37, 99, 235, 0.12);
 }
 
 .property-features__group {
@@ -7385,6 +7557,269 @@ body.profile-page {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
+}
+
+.feature-card {
+    position: relative;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.25s ease;
+}
+
+.feature-card__header {
+    display: flex;
+    align-items: flex-start;
+    gap: 18px;
+}
+
+.feature-card__titles {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.feature-card__toggle {
+    margin-inline-start: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(248, 250, 252, 0.9);
+    color: #0f172a;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.feature-card__toggle:hover,
+.feature-card__toggle:focus-visible {
+    border-color: rgba(37, 99, 235, 0.45);
+    color: #2563eb;
+    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.14);
+}
+
+.feature-card__toggle-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    transition: transform 0.2s ease;
+}
+
+.feature-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.feature-card__footer {
+    padding-top: 20px;
+    border-top: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.feature-card__footnote {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #475569;
+}
+
+.feature-card--collapsed .feature-card__body {
+    display: none;
+}
+
+.feature-card--collapsed .feature-card__toggle-icon {
+    transform: rotate(90deg);
+}
+
+.feature-card--highlighted {
+    border-color: rgba(37, 99, 235, 0.55);
+    box-shadow: 0 24px 52px rgba(37, 99, 235, 0.18);
+    transform: translateY(-3px);
+}
+
+.property-features__field.is-highlighted,
+.property-features__toggle.is-highlighted,
+.property-features__toggle-group-title.is-highlighted {
+    position: relative;
+    background: rgba(37, 99, 235, 0.08);
+    border-radius: 14px;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.3);
+}
+
+.property-features__toggle-group-title.is-highlighted {
+    padding: 6px 10px;
+}
+
+.property-features__aside {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.feature-summary-card,
+.feature-tips-card {
+    border-radius: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(255, 255, 255, 0.95);
+    padding: 24px;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.feature-summary-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.feature-summary-card__header h4 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: #0f172a;
+}
+
+.feature-summary-card__caption {
+    margin: 0;
+    color: #475569;
+    font-size: 0.9rem;
+}
+
+.feature-summary-card__progress {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 18px 0;
+}
+
+.feature-summary-card__progress-value {
+    min-width: 52px;
+    text-align: center;
+    font-weight: 700;
+    color: #2563eb;
+}
+
+.feature-summary-card__progress-track {
+    flex: 1;
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(226, 232, 240, 0.8);
+    overflow: hidden;
+}
+
+.feature-summary-card__progress-fill {
+    height: 100%;
+    width: 0%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #1d4ed8, #60a5fa);
+    transition: width 0.3s ease;
+}
+
+.feature-summary-card__stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    margin: 0;
+}
+
+.feature-summary-card__stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 12px;
+    border-radius: 14px;
+    background: rgba(248, 250, 252, 0.9);
+}
+
+.feature-summary-card__stat dt {
+    font-size: 0.78rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
+.feature-summary-card__stat dd {
+    margin: 0;
+    font-weight: 700;
+    color: #0f172a;
+    font-size: 1rem;
+}
+
+.feature-summary-card__footer {
+    margin-top: 18px;
+}
+
+.feature-summary-card__action {
+    width: 100%;
+    padding: 12px 16px;
+    border-radius: 12px;
+    border: none;
+    background: linear-gradient(135deg, #2563eb, #4338ca);
+    color: #fff;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.feature-summary-card__action:hover,
+.feature-summary-card__action:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(37, 99, 235, 0.25);
+}
+
+.feature-tips-card h4 {
+    margin: 0 0 12px;
+    font-size: 1.05rem;
+    color: #0f172a;
+}
+
+.feature-tips-card__list {
+    margin: 0;
+    padding-left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    color: #475569;
+    font-size: 0.92rem;
+}
+
+.feature-tips-card__cta {
+    margin-top: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.feature-tips-card__cta-label {
+    font-size: 0.82rem;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
+.feature-tips-card__link {
+    color: #2563eb;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.feature-tips-card__link:hover,
+.feature-tips-card__link:focus-visible {
+    text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+    .property-features__toolbar {
+        padding: 18px;
+    }
+
+    .feature-card__toggle-text {
+        display: none;
+    }
+
+    .feature-summary-card__stats {
+        grid-template-columns: 1fr;
+    }
 }
 
 .property-features__group[data-feature-category="desarrollo"] .property-features__group-icon {

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -229,9 +229,23 @@
 
                 <section class="publish-details__step" data-details-step="features">
                     <header class="property-features__header">
-                        <span class="property-features__badge">Paso 2 de 2</span>
-                        <h3 class="property-features__title">Define las características técnicas</h3>
-                        <p class="property-features__subtitle">Personaliza la ficha según la tipología seleccionada.</p>
+                        <div class="property-features__header-main">
+                            <div>
+                                <span class="property-features__badge">Paso 2 de 2</span>
+                                <h3 class="property-features__title">Define las características técnicas</h3>
+                                <p class="property-features__subtitle">Personaliza la ficha según la tipología seleccionada.</p>
+                            </div>
+                            <div class="property-features__actions" aria-label="Acciones rápidas de características">
+                                <button type="button" class="property-features__action-btn" data-features-expand>
+                                    <span aria-hidden="true">⤢</span>
+                                    <span>Expandir todo</span>
+                                </button>
+                                <button type="button" class="property-features__action-btn" data-features-collapse>
+                                    <span aria-hidden="true">⤡</span>
+                                    <span>Contraer todo</span>
+                                </button>
+                            </div>
+                        </div>
                         <div class="property-features__type">
                             <span class="property-features__type-icon" aria-hidden="true">
                                 <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false">
@@ -242,6 +256,10 @@
                             <div class="property-features__type-content">
                                 <span class="property-features__type-label" data-feature-type-label>Tipo no seleccionado</span>
                                 <p class="property-features__type-note" data-feature-summary>Selecciona un tipo de propiedad en el paso anterior para ver las opciones disponibles.</p>
+                            </div>
+                            <div class="property-features__badge-group" role="status">
+                                <span class="property-features__badge-pill" data-feature-progress>0 campos completados</span>
+                                <span class="property-features__badge-pill property-features__badge-pill--secondary" data-feature-optional>Incluye detalles opcionales para destacar</span>
                             </div>
                         </div>
                     </header>
@@ -256,489 +274,136 @@
                     </div>
 
                     <div class="property-features__content" data-features-content>
-                        <div class="property-features__group" data-feature-category="casa">
-                            <div class="property-features__group-header">
-                                <span class="property-features__group-icon" aria-hidden="true">
+                        <div class="property-features__layout">
+                            <div class="property-features__primary">
+                                <div class="property-features__toolbar" role="search">
+                                    <label for="feature-search" class="property-features__search-label">Busca una característica</label>
+                                    <div class="property-features__search">
+                                        <span aria-hidden="true" class="property-features__search-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+                                                <circle cx="11" cy="11" r="7" />
+                                                <line x1="21" y1="21" x2="16.65" y2="16.65" stroke-linecap="round" />
+                                            </svg>
+                                        </span>
+                                        <input id="feature-search" type="search" class="property-features__search-input" placeholder="Filtra por recámaras, amenidades, superficies…" autocomplete="off">
+                                        <button type="button" class="property-features__search-clear" data-feature-search-clear>Limpiar</button>
+                                    </div>
+                                    <div class="property-features__chips" aria-label="Amenidades rápidas">
+                                        <button type="button" class="property-features__chip" data-feature-chip="roofgarden">Roof Garden</button>
+                                        <button type="button" class="property-features__chip" data-feature-chip="petfriendly">Pet Friendly</button>
+                                        <button type="button" class="property-features__chip" data-feature-chip="security">Seguridad 24/7</button>
+                                        <button type="button" class="property-features__chip" data-feature-chip="amenities">Amenidades Premium</button>
+                                    </div>
+                                </div>
+
+                                <div class="property-features__groups" data-feature-groups>
+                                    <article class="property-features__group feature-card" data-feature-category="casa">
+                            <header class="property-features__group-header feature-card__header">
+                                <span class="property-features__group-icon feature-card__icon" aria-hidden="true">
                                     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false">
                                         <path d="M6 14 16 6l10 8v12a2 2 0 0 1-2 2h-6v-8h-4v8H8a2 2 0 0 1-2-2Z" fill="#ecfdf5" stroke="#10b981" stroke-width="1.6" stroke-linejoin="round"/>
                                     </svg>
                                 </span>
-                                <div>
+                                <div class="feature-card__titles">
                                     <h4>Distribución residencial</h4>
                                     <p>Describe la configuración general de la casa.</p>
                                 </div>
-                            </div>
-                            <div class="property-features__grid">
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-casa-recamaras">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="3" y="10" width="18" height="8" rx="2" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
-                                                <path d="M7 10V8a5 5 0 0 1 10 0v2" stroke="#2563eb" stroke-width="1.5" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Recámaras</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-casa-recamaras" name="recamaras_casas" class="property-features__input" placeholder="Ej. 3">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-casa-banos">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M5 11h14" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M6 11v3a5 5 0 0 0 5 5h2a5 5 0 0 0 5-5v-3" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
-                                                <path d="M9 7a3 3 0 0 1 6 0v4" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Baños</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-casa-banos" name="banos_casas" class="property-features__input" placeholder="Ej. 2.5">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-casa-estacionamientos">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="4" y="7" width="16" height="10" rx="2" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.6"/>
-                                                <path d="M7 17v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M17 17v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Estacionamientos</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-casa-estacionamientos" name="estacionamientos_casas" class="property-features__input" placeholder="Ej. 2">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-casa-superficie-total">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="4" y="4" width="16" height="16" rx="3" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.6"/>
-                                                <path d="M8 8h8v8H8z" fill="none" stroke="#f59e0b" stroke-width="1.6" stroke-linejoin="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Superficie total</span>
-                                    </label>
-                                    <input type="text" id="feature-casa-superficie-total" name="superficie_total_casas" class="property-features__input" placeholder="Ej. 240 m²">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-casa-superficie-construida">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M5 18V9l7-5 7 5v9" fill="#e0f2f1" stroke="#0f766e" stroke-width="1.6" stroke-linejoin="round"/>
-                                                <path d="M9 18v-5h6v5" stroke="#0f766e" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Superficie construida</span>
-                                    </label>
-                                    <input type="text" id="feature-casa-superficie-construida" name="superficie_construida_casas" class="property-features__input" placeholder="Ej. 180 m²">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-casa-niveles">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M6 18h12" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M6 14h8" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M6 10h4" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Niveles</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-casa-niveles" name="niveles_casas" class="property-features__input" placeholder="Ej. 2">
-                                </div>
-                            </div>
-                            <div class="property-features__toggles">
-                                <label class="property-features__toggle" for="feature-casa-terraza">
-                                    <input type="checkbox" id="feature-casa-terraza" name="terraza_casas">
-                                    <span class="property-features__toggle-icon" aria-hidden="true">
-                                        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M4 16h16" stroke="#f97316" stroke-width="1.6" stroke-linecap="round"/>
-                                            <path d="M6 16V9a6 6 0 0 1 12 0v7" stroke="#f97316" stroke-width="1.6" stroke-linecap="round"/>
-                                        </svg>
-                                    </span>
-                                    <span>Terraza</span>
-                                </label>
-                                <label class="property-features__toggle" for="feature-casa-alberca">
-                                    <input type="checkbox" id="feature-casa-alberca" name="alberca_casas">
-                                    <span class="property-features__toggle-icon" aria-hidden="true">
-                                        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M4 15c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
-                                            <path d="M4 11c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
-                                        </svg>
-                                    </span>
-                                    <span>Alberca</span>
-                                </label>
-                                <label class="property-features__toggle" for="feature-casa-amueblada">
-                                    <input type="checkbox" id="feature-casa-amueblada" name="amueblada_casas">
-                                    <span class="property-features__toggle-icon" aria-hidden="true">
-                                        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <rect x="3" y="10" width="18" height="8" rx="2" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.6"/>
-                                            <path d="M5 18v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
-                                            <path d="M19 18v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
-                                        </svg>
-                                    </span>
-                                    <span>Amueblada</span>
-                                </label>
-                            </div>
-                        </div>
-
-                        <div class="property-features__group" data-feature-category="departamento">
-                            <div class="property-features__group-header">
-                                <span class="property-features__group-icon" aria-hidden="true">
-                                    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                                        <rect x="8" y="4" width="16" height="24" rx="2.5" fill="#eef2ff" stroke="#4f46e5" stroke-width="1.6"/>
-                                        <path d="M12 10h4m4 0h4M12 16h4m4 0h4M12 22h4m4 0h4" stroke="#4f46e5" stroke-width="1.4" stroke-linecap="round"/>
-                                    </svg>
-                                </span>
-                                <div>
-                                    <h4>Ficha del departamento</h4>
-                                    <p>Agrega los datos clave de la unidad.</p>
-                                </div>
-                            </div>
-                            <div class="property-features__grid">
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-departamento-recamaras">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="3" y="10" width="18" height="8" rx="2" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
-                                                <path d="M7 10V8a5 5 0 0 1 10 0v2" stroke="#2563eb" stroke-width="1.5" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Recámaras</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-departamento-recamaras" name="recamaras_departamentos" class="property-features__input" placeholder="Ej. 2">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-departamento-banos">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M5 11h14" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M6 11v3a5 5 0 0 0 5 5h2a5 5 0 0 0 5-5v-3" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
-                                                <path d="M9 7a3 3 0 0 1 6 0v4" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Baños</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-departamento-banos" name="banos_departamentos" class="property-features__input" placeholder="Ej. 2">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-departamento-estacionamientos">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="4" y="7" width="16" height="10" rx="2" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.6"/>
-                                                <path d="M7 17v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M17 17v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Estacionamientos</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-departamento-estacionamientos" name="estacionamientos_departamentos" class="property-features__input" placeholder="Ej. 1">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-departamento-superficie-total">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="4" y="4" width="16" height="16" rx="3" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.6"/>
-                                                <path d="M8 8h8v8H8z" fill="none" stroke="#f59e0b" stroke-width="1.6" stroke-linejoin="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Superficie total</span>
-                                    </label>
-                                    <input type="text" id="feature-departamento-superficie-total" name="superficie_total_departamentos" class="property-features__input" placeholder="Ej. 95 m²">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-departamento-piso">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M8 5h8v14H8z" fill="#f1f5f9" stroke="#1d4ed8" stroke-width="1.6" stroke-linejoin="round"/>
-                                                <path d="M10 9h4m-4 4h4" stroke="#1d4ed8" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Piso</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-departamento-piso" name="piso_departamentos" class="property-features__input" placeholder="Ej. 12">
-                                </div>
-                            </div>
-                            <div class="property-features__toggles">
-                                <label class="property-features__toggle" for="feature-departamento-terraza">
-                                    <input type="checkbox" id="feature-departamento-terraza" name="terraza_departamentos">
-                                    <span class="property-features__toggle-icon" aria-hidden="true">
-                                        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M4 16h16" stroke="#f97316" stroke-width="1.6" stroke-linecap="round"/>
-                                            <path d="M6 16V9a6 6 0 0 1 12 0v7" stroke="#f97316" stroke-width="1.6" stroke-linecap="round"/>
-                                        </svg>
-                                    </span>
-                                    <span>Terraza privada</span>
-                                </label>
-                                <div class="property-features__toggle-group" role="group" aria-labelledby="feature-departamento-amenidades">
-                                    <span id="feature-departamento-amenidades" class="property-features__toggle-group-title">Amenidades</span>
-                                    <div class="property-features__toggle-list">
-                                        <label class="property-features__toggle" for="feature-departamento-gimnasio">
-                                            <input type="checkbox" id="feature-departamento-gimnasio" name="gimnasio_departamentos">
-                                            <span class="property-features__toggle-icon" aria-hidden="true">
+                                <button type="button" class="feature-card__toggle" data-feature-toggle aria-expanded="true" aria-controls="feature-group-casa">
+                                    <span class="feature-card__toggle-text">Contraer</span>
+                                    <span class="feature-card__toggle-icon" aria-hidden="true">▾</span>
+                                </button>
+                            </header>
+                            <div class="feature-card__body" id="feature-group-casa">
+                                <div class="property-features__grid">
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-casa-recamaras">
+                                            <span aria-hidden="true" class="property-features__label-icon">
                                                 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                    <path d="M5 8h2v8H5zM17 8h2v8h-2z" fill="#60a5fa"/>
-                                                    <rect x="8" y="6" width="8" height="12" rx="2" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.4"/>
+                                                    <rect x="3" y="10" width="18" height="8" rx="2" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+                                                    <path d="M7 10V8a5 5 0 0 1 10 0v2" stroke="#2563eb" stroke-width="1.5" stroke-linecap="round"/>
                                                 </svg>
                                             </span>
-                                            <span>Gimnasio</span>
+                                            <span>Recámaras</span>
                                         </label>
-                                        <label class="property-features__toggle" for="feature-departamento-alberca">
-                                            <input type="checkbox" id="feature-departamento-alberca" name="alberca_departamentos">
-                                            <span class="property-features__toggle-icon" aria-hidden="true">
+                                        <input type="number" min="0" id="feature-casa-recamaras" name="recamaras_casas" class="property-features__input" placeholder="Ej. 3">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-casa-banos">
+                                            <span aria-hidden="true" class="property-features__label-icon">
                                                 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                    <path d="M4 15c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
-                                                    <path d="M4 11c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M5 11h14" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M6 11v3a5 5 0 0 0 5 5h2a5 5 0 0 0 5-5v-3" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
+                                                    <path d="M9 7a3 3 0 0 1 6 0v4" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
                                                 </svg>
                                             </span>
-                                            <span>Alberca</span>
+                                            <span>Baños</span>
                                         </label>
-                                        <label class="property-features__toggle" for="feature-departamento-salon-eventos">
-                                            <input type="checkbox" id="feature-departamento-salon-eventos" name="salon_eventos_departamentos">
-                                            <span class="property-features__toggle-icon" aria-hidden="true">
+                                        <input type="number" min="0" id="feature-casa-banos" name="banos_casas" class="property-features__input" placeholder="Ej. 2.5">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-casa-estacionamientos">
+                                            <span aria-hidden="true" class="property-features__label-icon">
                                                 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                    <rect x="4" y="8" width="16" height="10" rx="2" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.4"/>
-                                                    <path d="M7 12h10" stroke="#7c3aed" stroke-width="1.4" stroke-linecap="round"/>
+                                                    <rect x="4" y="7" width="16" height="10" rx="2" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.6"/>
+                                                    <path d="M7 17v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M17 17v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
                                                 </svg>
                                             </span>
-                                            <span>Salón de eventos</span>
+                                            <span>Estacionamientos</span>
                                         </label>
+                                        <input type="number" min="0" id="feature-casa-estacionamientos" name="estacionamientos_casas" class="property-features__input" placeholder="Ej. 2">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-casa-superficie-total">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="4" y="4" width="16" height="16" rx="3" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.6"/>
+                                                    <path d="M8 8h8v8H8z" fill="none" stroke="#f59e0b" stroke-width="1.6" stroke-linejoin="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Superficie total</span>
+                                        </label>
+                                        <input type="text" id="feature-casa-superficie-total" name="superficie_total_casas" class="property-features__input" placeholder="Ej. 240 m²">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-casa-superficie-construida">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M5 18V9l7-5 7 5v9" fill="#e0f2f1" stroke="#0f766e" stroke-width="1.6" stroke-linejoin="round"/>
+                                                    <path d="M9 18v-5h6v5" stroke="#0f766e" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Superficie construida</span>
+                                        </label>
+                                        <input type="text" id="feature-casa-superficie-construida" name="superficie_construida_casas" class="property-features__input" placeholder="Ej. 180 m²">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-casa-niveles">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M6 18h12" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M6 14h8" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M6 10h4" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Niveles</span>
+                                        </label>
+                                        <input type="number" min="0" id="feature-casa-niveles" name="niveles_casas" class="property-features__input" placeholder="Ej. 2">
                                     </div>
                                 </div>
-                                <label class="property-features__toggle" for="feature-departamento-elevador">
-                                    <input type="checkbox" id="feature-departamento-elevador" name="elevador_departamentos">
-                                    <span class="property-features__toggle-icon" aria-hidden="true">
-                                        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <rect x="6" y="4" width="12" height="16" rx="2" fill="#f1f5f9" stroke="#1d4ed8" stroke-width="1.6"/>
-                                            <path d="M10 9h4M10 15h4" stroke="#1d4ed8" stroke-width="1.6" stroke-linecap="round"/>
-                                            <path d="M12 6v2" stroke="#1d4ed8" stroke-width="1.6" stroke-linecap="round"/>
-                                        </svg>
-                                    </span>
-                                    <span>Elevador</span>
-                                </label>
-                            </div>
-                        </div>
-
-                        <div class="property-features__group" data-feature-category="terreno">
-                            <div class="property-features__group-header">
-                                <span class="property-features__group-icon" aria-hidden="true">
-                                    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                                        <path d="M4 24 16 8l12 16" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.6" stroke-linejoin="round"/>
-                                        <path d="M8 24h16" stroke="#f59e0b" stroke-width="1.6" stroke-linecap="round"/>
-                                    </svg>
-                                </span>
-                                <div>
-                                    <h4>Información del terreno</h4>
-                                    <p>Comparte medidas, servicios y potencial de desarrollo.</p>
-                                </div>
-                            </div>
-                            <div class="property-features__grid">
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-terreno-superficie-total">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="4" y="4" width="16" height="16" rx="3" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.6"/>
-                                                <path d="M8 8h8v8H8z" fill="none" stroke="#f59e0b" stroke-width="1.6" stroke-linejoin="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Superficie total</span>
-                                    </label>
-                                    <input type="text" id="feature-terreno-superficie-total" name="superficie_total_terrenos" class="property-features__input" placeholder="Ej. 1,200 m²">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-terreno-tipo-suelo">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M4 18h16l-3-6-5 4-3-4z" fill="#fef9c3" stroke="#d97706" stroke-width="1.6" stroke-linejoin="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Tipo de suelo</span>
-                                    </label>
-                                    <input type="text" id="feature-terreno-tipo-suelo" name="tipo_suelo_terrenos" class="property-features__input" placeholder="Ej. Rocoso, nivelado">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-terreno-frente">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M5 7h14" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M5 17h14" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Frente</span>
-                                    </label>
-                                    <input type="text" id="feature-terreno-frente" name="frente_terrenos" class="property-features__input" placeholder="Ej. 30 m">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-terreno-fondo">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M7 5v14" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M17 5v14" stroke="#14b8a6" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Fondo</span>
-                                    </label>
-                                    <input type="text" id="feature-terreno-fondo" name="fondo_terrenos" class="property-features__input" placeholder="Ej. 40 m">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-terreno-tipo-propiedad">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M4 15h16" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M6 11h12" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M8 7h8" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Tipo de propiedad</span>
-                                    </label>
-                                    <select id="feature-terreno-tipo-propiedad" name="tipo_propiedad_terrenos" class="property-features__input">
-                                        <option value="">Selecciona una opción</option>
-                                        <option value="residencial">Residencial</option>
-                                        <option value="comercial">Comercial</option>
-                                        <option value="industrial">Industrial</option>
-                                        <option value="mixto">Uso mixto</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="property-features__toggle-group" role="group" aria-labelledby="feature-terreno-servicios">
-                                <span id="feature-terreno-servicios" class="property-features__toggle-group-title">Servicios disponibles</span>
-                                <div class="property-features__toggle-list">
-                                    <label class="property-features__toggle" for="feature-terreno-luz">
-                                        <input type="checkbox" id="feature-terreno-luz" name="luz_terrenos">
+                                <div class="property-features__toggles">
+                                    <label class="property-features__toggle" for="feature-casa-terraza">
+                                        <input type="checkbox" id="feature-casa-terraza" name="terraza_casas">
                                         <span class="property-features__toggle-icon" aria-hidden="true">
                                             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M12 4a6 6 0 0 1 6 6c0 2.2-1 3.6-2 4.6a3 3 0 0 0-1 2.2V18h-6v-1.2a3 3 0 0 0-1-2.2c-1-1-2-2.4-2-4.6a6 6 0 0 1 6-6Z" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.4"/>
-                                                <path d="M10 20h4" stroke="#f59e0b" stroke-width="1.4" stroke-linecap="round"/>
+                                                <path d="M4 16h16" stroke="#f97316" stroke-width="1.6" stroke-linecap="round"/>
+                                                <path d="M6 16V9a6 6 0 0 1 12 0v7" stroke="#f97316" stroke-width="1.6" stroke-linecap="round"/>
                                             </svg>
                                         </span>
-                                        <span>Luz</span>
+                                        <span>Terraza</span>
                                     </label>
-                                    <label class="property-features__toggle" for="feature-terreno-agua">
-                                        <input type="checkbox" id="feature-terreno-agua" name="agua_terrenos">
-                                        <span class="property-features__toggle-icon" aria-hidden="true">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M12 4s5 5.2 5 9a5 5 0 1 1-10 0c0-3.8 5-9 5-9Z" fill="#e0f2fe" stroke="#0284c7" stroke-width="1.4"/>
-                                            </svg>
-                                        </span>
-                                        <span>Agua</span>
-                                    </label>
-                                    <label class="property-features__toggle" for="feature-terreno-drenaje">
-                                        <input type="checkbox" id="feature-terreno-drenaje" name="drenaje_terrenos">
-                                        <span class="property-features__toggle-icon" aria-hidden="true">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M6 9h12v2a6 6 0 0 1-12 0Z" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.4" stroke-linejoin="round"/>
-                                                <path d="M9 14h6" stroke="#7c3aed" stroke-width="1.4" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Drenaje</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="property-features__group" data-feature-category="desarrollo">
-                            <div class="property-features__group-header">
-                                <span class="property-features__group-icon" aria-hidden="true">
-                                    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                                        <path d="M6 24V10l6-3v17" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
-                                        <path d="M16 24V6l6 3v15" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
-                                        <path d="M24 24v-9l2 1v8" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
-                                    </svg>
-                                </span>
-                                <div>
-                                    <h4>Proyecto en desarrollo</h4>
-                                    <p>Detalla etapas, amenidades y alcance del proyecto.</p>
-                                </div>
-                            </div>
-                            <div class="property-features__grid">
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-desarrollo-unidades">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="4" y="4" width="16" height="16" rx="2" fill="#e0f2fe" stroke="#2563eb" stroke-width="1.4"/>
-                                                <path d="M8 8h8v8H8z" fill="none" stroke="#2563eb" stroke-width="1.4" stroke-linejoin="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Número de unidades</span>
-                                    </label>
-                                    <input type="number" min="0" id="feature-desarrollo-unidades" name="num_unidades_desarrollos" class="property-features__input" placeholder="Ej. 120">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-desarrollo-superficie-min">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="5" y="5" width="7" height="7" rx="1.5" fill="#dcfce7" stroke="#16a34a" stroke-width="1.4"/>
-                                            </svg>
-                                        </span>
-                                        <span>Superficie mínima</span>
-                                    </label>
-                                    <input type="text" id="feature-desarrollo-superficie-min" name="superficie_min_desarrollos" class="property-features__input" placeholder="Ej. 45 m²">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-desarrollo-superficie-max">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="12" y="12" width="7" height="7" rx="1.5" fill="#dcfce7" stroke="#16a34a" stroke-width="1.4"/>
-                                            </svg>
-                                        </span>
-                                        <span>Superficie máxima</span>
-                                    </label>
-                                    <input type="text" id="feature-desarrollo-superficie-max" name="superficie_max_desarrollos" class="property-features__input" placeholder="Ej. 180 m²">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-desarrollo-rango-recamaras">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <rect x="3" y="10" width="18" height="8" rx="2" fill="#dbeafe" stroke="#2563eb" stroke-width="1.4"/>
-                                                <path d="M7 10V8a5 5 0 0 1 10 0v2" stroke="#2563eb" stroke-width="1.4" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Rango de recámaras</span>
-                                    </label>
-                                    <input type="text" id="feature-desarrollo-rango-recamaras" name="rango_recamaras_desarrollos" class="property-features__input" placeholder="Ej. 1 a 4">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-desarrollo-rango-banos">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M5 11h14" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M6 11v3a5 5 0 0 0 5 5h2a5 5 0 0 0 5-5v-3" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Rango de baños</span>
-                                    </label>
-                                    <input type="text" id="feature-desarrollo-rango-banos" name="rango_banos_desarrollos" class="property-features__input" placeholder="Ej. 1 a 3.5">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-desarrollo-etapas">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M4 18h16" stroke="#2563eb" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M4 14h10" stroke="#2563eb" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M4 10h6" stroke="#2563eb" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Etapas</span>
-                                    </label>
-                                    <input type="text" id="feature-desarrollo-etapas" name="etapas_desarrollos" class="property-features__input" placeholder="Ej. 3 fases">
-                                </div>
-                                <div class="property-features__field">
-                                    <label class="property-features__field-label" for="feature-desarrollo-entrega">
-                                        <span aria-hidden="true" class="property-features__label-icon">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M12 3v18" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M6 7h12" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                                <path d="M8 12h8" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
-                                            </svg>
-                                        </span>
-                                        <span>Entrega estimada</span>
-                                    </label>
-                                    <input type="text" id="feature-desarrollo-entrega" name="entrega_estimada_desarrollos" class="property-features__input" placeholder="Ej. 4T 2025">
-                                </div>
-                            </div>
-                            <div class="property-features__toggle-group" role="group" aria-labelledby="feature-desarrollo-amenidades">
-                                <span id="feature-desarrollo-amenidades" class="property-features__toggle-group-title">Amenidades destacadas</span>
-                                <div class="property-features__toggle-list">
-                                    <label class="property-features__toggle" for="feature-desarrollo-alberca">
-                                        <input type="checkbox" id="feature-desarrollo-alberca" name="alberca_desarrollos">
+                                    <label class="property-features__toggle" for="feature-casa-alberca">
+                                        <input type="checkbox" id="feature-casa-alberca" name="alberca_casas">
                                         <span class="property-features__toggle-icon" aria-hidden="true">
                                             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                                                 <path d="M4 15c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
@@ -747,42 +412,492 @@
                                         </span>
                                         <span>Alberca</span>
                                     </label>
-                                    <label class="property-features__toggle" for="feature-desarrollo-areas-verdes">
-                                        <input type="checkbox" id="feature-desarrollo-areas-verdes" name="areas_verdes_desarrollos">
+                                    <label class="property-features__toggle" for="feature-casa-amueblada">
+                                        <input type="checkbox" id="feature-casa-amueblada" name="amueblada_casas">
                                         <span class="property-features__toggle-icon" aria-hidden="true">
                                             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M12 4c3 3 5 5.5 5 8.5a5 5 0 0 1-10 0C7 9.5 9 7 12 4Z" fill="#dcfce7" stroke="#16a34a" stroke-width="1.4"/>
+                                                <rect x="3" y="10" width="18" height="8" rx="2" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.6"/>
+                                                <path d="M5 18v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
+                                                <path d="M19 18v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
                                             </svg>
                                         </span>
-                                        <span>Áreas verdes</span>
-                                    </label>
-                                    <label class="property-features__toggle" for="feature-desarrollo-gimnasio">
-                                        <input type="checkbox" id="feature-desarrollo-gimnasio" name="gimnasio_desarrollos">
-                                        <span class="property-features__toggle-icon" aria-hidden="true">
-                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M5 8h2v8H5zM17 8h2v8h-2z" fill="#60a5fa"/>
-                                                <rect x="8" y="6" width="8" height="12" rx="2" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.4"/>
-                                            </svg>
-                                        </span>
-                                        <span>Gimnasio</span>
+                                        <span>Amueblada</span>
                                     </label>
                                 </div>
+                                <footer class="feature-card__footer">
+                                    <p class="feature-card__footnote">Tip: Resalta si cuentas con recámara en planta baja o espacios multifuncionales.</p>
+                                </footer>
                             </div>
-                            <div class="property-features__toggles">
-                                <label class="property-features__toggle" for="feature-desarrollo-pet-friendly">
-                                    <input type="checkbox" id="feature-desarrollo-pet-friendly" name="pet_friendly_desarrollos">
-                                    <span class="property-features__toggle-icon" aria-hidden="true">
-                                        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M8 11a4 4 0 0 1 8 0v1a4 4 0 0 1-8 0Z" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.4"/>
-                                            <circle cx="7" cy="8" r="1.5" fill="#f59e0b"/>
-                                            <circle cx="17" cy="8" r="1.5" fill="#f59e0b"/>
-                                        </svg>
-                                    </span>
-                                    <span>Pet friendly</span>
-                                </label>
+                                    </article>
+
+                                    <article class="property-features__group feature-card" data-feature-category="departamento">
+                            <header class="property-features__group-header feature-card__header">
+                                <span class="property-features__group-icon feature-card__icon" aria-hidden="true">
+                                    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                                        <rect x="8" y="4" width="16" height="24" rx="2.5" fill="#eef2ff" stroke="#4f46e5" stroke-width="1.6"/>
+                                        <path d="M12 10h4m4 0h4M12 16h4m4 0h4M12 22h4m4 0h4" stroke="#4f46e5" stroke-width="1.4" stroke-linecap="round"/>
+                                    </svg>
+                                </span>
+                                <div class="feature-card__titles">
+                                    <h4>Ficha del departamento</h4>
+                                    <p>Agrega los datos clave de la unidad.</p>
+                                </div>
+                                <button type="button" class="feature-card__toggle" data-feature-toggle aria-expanded="true" aria-controls="feature-group-departamento">
+                                    <span class="feature-card__toggle-text">Contraer</span>
+                                    <span class="feature-card__toggle-icon" aria-hidden="true">▾</span>
+                                </button>
+                            </header>
+                            <div class="feature-card__body" id="feature-group-departamento">
+                                <div class="property-features__grid">
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-departamento-recamaras">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="3" y="10" width="18" height="8" rx="2" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+                                                    <path d="M7 10V8a5 5 0 0 1 10 0v2" stroke="#2563eb" stroke-width="1.5" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Recámaras</span>
+                                        </label>
+                                        <input type="number" min="0" id="feature-departamento-recamaras" name="recamaras_departamentos" class="property-features__input" placeholder="Ej. 2">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-departamento-banos">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M5 11h14" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M6 11v3a5 5 0 0 0 5 5h2a5 5 0 0 0 5-5v-3" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
+                                                    <path d="M9 7a3 3 0 0 1 6 0v4" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Baños</span>
+                                        </label>
+                                        <input type="number" min="0" id="feature-departamento-banos" name="banos_departamentos" class="property-features__input" placeholder="Ej. 2">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-departamento-estacionamientos">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="4" y="7" width="16" height="10" rx="2" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.6"/>
+                                                    <path d="M7 17v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M17 17v2" stroke="#7c3aed" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Estacionamientos</span>
+                                        </label>
+                                        <input type="number" min="0" id="feature-departamento-estacionamientos" name="estacionamientos_departamentos" class="property-features__input" placeholder="Ej. 1">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-departamento-superficie-total">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="4" y="4" width="16" height="16" rx="3" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.6"/>
+                                                    <path d="M8 8h8v8H8z" fill="none" stroke="#f59e0b" stroke-width="1.6" stroke-linejoin="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Superficie total</span>
+                                        </label>
+                                        <input type="text" id="feature-departamento-superficie-total" name="superficie_total_departamentos" class="property-features__input" placeholder="Ej. 95 m²">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-departamento-piso">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M8 5h8v14H8z" fill="#f1f5f9" stroke="#1d4ed8" stroke-width="1.6" stroke-linejoin="round"/>
+                                                    <path d="M10 9h4m-4 4h4" stroke="#1d4ed8" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Piso</span>
+                                        </label>
+                                        <input type="number" min="0" id="feature-departamento-piso" name="piso_departamentos" class="property-features__input" placeholder="Ej. 12">
+                                    </div>
+                                </div>
+                                <div class="property-features__toggles">
+                                    <label class="property-features__toggle" for="feature-departamento-terraza">
+                                        <input type="checkbox" id="feature-departamento-terraza" name="terraza_departamentos">
+                                        <span class="property-features__toggle-icon" aria-hidden="true">
+                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                <path d="M4 16h16" stroke="#f97316" stroke-width="1.6" stroke-linecap="round"/>
+                                                <path d="M6 16V9a6 6 0 0 1 12 0v7" stroke="#f97316" stroke-width="1.6" stroke-linecap="round"/>
+                                            </svg>
+                                        </span>
+                                        <span>Terraza privada</span>
+                                    </label>
+                                    <div class="property-features__toggle-group" role="group" aria-labelledby="feature-departamento-amenidades">
+                                        <span id="feature-departamento-amenidades" class="property-features__toggle-group-title">Amenidades</span>
+                                        <div class="property-features__toggle-list">
+                                            <label class="property-features__toggle" for="feature-departamento-gimnasio">
+                                                <input type="checkbox" id="feature-departamento-gimnasio" name="gimnasio_departamentos">
+                                                <span class="property-features__toggle-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M5 8h2v8H5zM17 8h2v8h-2z" fill="#60a5fa"/>
+                                                        <rect x="8" y="6" width="8" height="12" rx="2" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.4"/>
+                                                    </svg>
+                                                </span>
+                                                <span>Gimnasio</span>
+                                            </label>
+                                            <label class="property-features__toggle" for="feature-departamento-alberca">
+                                                <input type="checkbox" id="feature-departamento-alberca" name="alberca_departamentos">
+                                                <span class="property-features__toggle-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M4 15c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
+                                                        <path d="M4 11c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
+                                                    </svg>
+                                                </span>
+                                                <span>Alberca</span>
+                                            </label>
+                                            <label class="property-features__toggle" for="feature-departamento-salon-eventos">
+                                                <input type="checkbox" id="feature-departamento-salon-eventos" name="salon_eventos_departamentos">
+                                                <span class="property-features__toggle-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <rect x="4" y="8" width="16" height="10" rx="2" fill="#ede9fe" stroke="#7c3aed" stroke-width="1.4"/>
+                                                        <path d="M7 12h10" stroke="#7c3aed" stroke-width="1.4" stroke-linecap="round"/>
+                                                    </svg>
+                                                </span>
+                                                <span>Salón de eventos</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <label class="property-features__toggle" for="feature-departamento-elevador">
+                                        <input type="checkbox" id="feature-departamento-elevador" name="elevador_departamentos">
+                                        <span class="property-features__toggle-icon" aria-hidden="true">
+                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                <rect x="6" y="4" width="12" height="16" rx="2" fill="#f1f5f9" stroke="#1d4ed8" stroke-width="1.6"/>
+                                                <path d="M10 9h4M10 15h4" stroke="#1d4ed8" stroke-width="1.6" stroke-linecap="round"/>
+                                                <path d="M12 6v2" stroke="#1d4ed8" stroke-width="1.6" stroke-linecap="round"/>
+                                            </svg>
+                                        </span>
+                                        <span>Elevador</span>
+                                    </label>
+                                </div>
+                                <footer class="feature-card__footer">
+                                    <p class="feature-card__footnote">Tip: Destaca vistas privilegiadas, doble altura o acabados premium de la torre.</p>
+                                </footer>
+                            </div>
+                                    </article>
+
+                                    <article class="property-features__group feature-card" data-feature-category="terreno">
+                            <header class="property-features__group-header feature-card__header">
+                                <span class="property-features__group-icon feature-card__icon" aria-hidden="true">
+                                    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                                        <path d="M4 24 16 8l12 16" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.6" stroke-linejoin="round"/>
+                                        <path d="M8 24h16" stroke="#f59e0b" stroke-width="1.6" stroke-linecap="round"/>
+                                    </svg>
+                                </span>
+                                <div class="feature-card__titles">
+                                    <h4>Información del terreno</h4>
+                                    <p>Comparte medidas, servicios y potencial de desarrollo.</p>
+                                </div>
+                                <button type="button" class="feature-card__toggle" data-feature-toggle aria-expanded="true" aria-controls="feature-group-terreno">
+                                    <span class="feature-card__toggle-text">Contraer</span>
+                                    <span class="feature-card__toggle-icon" aria-hidden="true">▾</span>
+                                </button>
+                            </header>
+                            <div class="feature-card__body" id="feature-group-terreno">
+                                <div class="property-features__grid">
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-terreno-superficie-total">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="4" y="4" width="16" height="16" rx="3" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.6"/>
+                                                    <path d="M8 8h8v8H8z" fill="none" stroke="#f59e0b" stroke-width="1.6" stroke-linejoin="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Superficie total</span>
+                                        </label>
+                                        <input type="text" id="feature-terreno-superficie-total" name="superficie_total_terrenos" class="property-features__input" placeholder="Ej. 1,200 m²">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-terreno-tipo-suelo">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M4 18h16l-3-6-5 4-3-4z" fill="#fef9c3" stroke="#d97706" stroke-width="1.6" stroke-linejoin="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Tipo de suelo</span>
+                                        </label>
+                                        <input type="text" id="feature-terreno-tipo-suelo" name="tipo_suelo_terrenos" class="property-features__input" placeholder="Ej. Rocoso, nivelado">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-terreno-frente">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M5 18V6h14v12" fill="#f1f5f9" stroke="#1f2937" stroke-width="1.6" stroke-linejoin="round"/>
+                                                    <path d="M5 10h14" stroke="#1f2937" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Frente</span>
+                                        </label>
+                                        <input type="text" id="feature-terreno-frente" name="frente_terrenos" class="property-features__input" placeholder="Ej. 20 m">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-terreno-fondo">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M5 18V6h14v12" fill="#f1f5f9" stroke="#1f2937" stroke-width="1.6" stroke-linejoin="round"/>
+                                                    <path d="M12 6v12" stroke="#1f2937" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Fondo</span>
+                                        </label>
+                                        <input type="text" id="feature-terreno-fondo" name="fondo_terrenos" class="property-features__input" placeholder="Ej. 60 m">
+                                    </div>
+                                </div>
+                                <div class="property-features__toggles">
+                                    <div class="property-features__toggle-group" role="group" aria-labelledby="feature-terreno-servicios">
+                                        <span id="feature-terreno-servicios" class="property-features__toggle-group-title">Servicios</span>
+                                        <div class="property-features__toggle-list">
+                                            <label class="property-features__toggle" for="feature-terreno-agua">
+                                                <input type="checkbox" id="feature-terreno-agua" name="agua_terrenos">
+                                                <span class="property-features__toggle-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M12 4s6 6 6 10a6 6 0 0 1-12 0c0-4 6-10 6-10Z" fill="#cffafe" stroke="#0891b2" stroke-width="1.6"/>
+                                                    </svg>
+                                                </span>
+                                                <span>Agua</span>
+                                            </label>
+                                            <label class="property-features__toggle" for="feature-terreno-luz">
+                                                <input type="checkbox" id="feature-terreno-luz" name="luz_terrenos">
+                                                <span class="property-features__toggle-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M12 4v4m0 8v4m-4-4h8M7 7l2.5 2.5M14.5 9.5 17 7M7 17l2.5-2.5M14.5 14.5 17 17" stroke="#fbbf24" stroke-width="1.6" stroke-linecap="round"/>
+                                                    </svg>
+                                                </span>
+                                                <span>Electricidad</span>
+                                            </label>
+                                            <label class="property-features__toggle" for="feature-terreno-drenaje">
+                                                <input type="checkbox" id="feature-terreno-drenaje" name="drenaje_terrenos">
+                                                <span class="property-features__toggle-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path d="M4 12h16" stroke="#2563eb" stroke-width="1.6" stroke-linecap="round"/>
+                                                        <path d="M6 12v5a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3v-5" stroke="#2563eb" stroke-width="1.6" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
+                                                <span>Drenaje</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <label class="property-features__toggle" for="feature-terreno-escrituras">
+                                        <input type="checkbox" id="feature-terreno-escrituras" name="escrituras_terrenos">
+                                        <span class="property-features__toggle-icon" aria-hidden="true">
+                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                <path d="M5 4h9l5 5v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2Z" fill="#f8fafc" stroke="#1d4ed8" stroke-width="1.6" stroke-linejoin="round"/>
+                                                <path d="m14 4-.5 5h5" stroke="#1d4ed8" stroke-width="1.6" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
+                                        <span>Escriturado</span>
+                                    </label>
+                                </div>
+                                <footer class="feature-card__footer">
+                                    <p class="feature-card__footnote">Tip: Añade información de uso de suelo o proyectos autorizados para aumentar la confianza del inversionista.</p>
+                                </footer>
+                            </div>
+                                    </article>
+                                    <article class="property-features__group feature-card" data-feature-category="desarrollo">
+                            <header class="property-features__group-header feature-card__header">
+                                <span class="property-features__group-icon feature-card__icon" aria-hidden="true">
+                                    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                                        <path d="M6 24V10l6-3v17" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
+                                        <path d="M16 24V6l6 3v15" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
+                                        <path d="M24 24v-9l2 1v8" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
+                                    </svg>
+                                </span>
+                                <div class="feature-card__titles">
+                                    <h4>Proyecto en desarrollo</h4>
+                                    <p>Detalla etapas, amenidades y alcance del proyecto.</p>
+                                </div>
+                                <button type="button" class="feature-card__toggle" data-feature-toggle aria-expanded="true" aria-controls="feature-group-desarrollo">
+                                    <span class="feature-card__toggle-text">Contraer</span>
+                                    <span class="feature-card__toggle-icon" aria-hidden="true">▾</span>
+                                </button>
+                            </header>
+                            <div class="feature-card__body" id="feature-group-desarrollo">
+                                <div class="property-features__grid">
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-desarrollo-unidades">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="4" y="4" width="16" height="16" rx="2" fill="#e0f2fe" stroke="#2563eb" stroke-width="1.4"/>
+                                                    <path d="M8 8h8v8H8z" fill="none" stroke="#2563eb" stroke-width="1.4" stroke-linejoin="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Número de unidades</span>
+                                        </label>
+                                        <input type="number" min="0" id="feature-desarrollo-unidades" name="num_unidades_desarrollos" class="property-features__input" placeholder="Ej. 120">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-desarrollo-superficie-min">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="5" y="5" width="7" height="7" rx="1.5" fill="#dcfce7" stroke="#16a34a" stroke-width="1.4"/>
+                                                </svg>
+                                            </span>
+                                            <span>Superficie mínima</span>
+                                        </label>
+                                        <input type="text" id="feature-desarrollo-superficie-min" name="superficie_min_desarrollos" class="property-features__input" placeholder="Ej. 45 m²">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-desarrollo-superficie-max">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="12" y="12" width="7" height="7" rx="1.5" fill="#dcfce7" stroke="#16a34a" stroke-width="1.4"/>
+                                                </svg>
+                                            </span>
+                                            <span>Superficie máxima</span>
+                                        </label>
+                                        <input type="text" id="feature-desarrollo-superficie-max" name="superficie_max_desarrollos" class="property-features__input" placeholder="Ej. 180 m²">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-desarrollo-rango-recamaras">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <rect x="3" y="10" width="18" height="8" rx="2" fill="#dbeafe" stroke="#2563eb" stroke-width="1.4"/>
+                                                    <path d="M7 10V8a5 5 0 0 1 10 0v2" stroke="#2563eb" stroke-width="1.4" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Rango de recámaras</span>
+                                        </label>
+                                        <input type="text" id="feature-desarrollo-rango-recamaras" name="rango_recamaras_desarrollos" class="property-features__input" placeholder="Ej. 1 a 4">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-desarrollo-rango-banos">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M5 11h14" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M6 11v3a5 5 0 0 0 5 5h2a5 5 0 0 0 5-5v-3" stroke="#0ea5e9" stroke-width="1.6" stroke-linejoin="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Rango de baños</span>
+                                        </label>
+                                        <input type="text" id="feature-desarrollo-rango-banos" name="rango_banos_desarrollos" class="property-features__input" placeholder="Ej. 1 a 3.5">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-desarrollo-etapas">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M4 18h16" stroke="#2563eb" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M4 14h10" stroke="#2563eb" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M4 10h6" stroke="#2563eb" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Etapas</span>
+                                        </label>
+                                        <input type="text" id="feature-desarrollo-etapas" name="etapas_desarrollos" class="property-features__input" placeholder="Ej. 3 fases">
+                                    </div>
+                                    <div class="property-features__field">
+                                        <label class="property-features__field-label" for="feature-desarrollo-entrega">
+                                            <span aria-hidden="true" class="property-features__label-icon">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M12 3v18" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M6 7h12" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M8 12h8" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Entrega estimada</span>
+                                        </label>
+                                        <input type="text" id="feature-desarrollo-entrega" name="entrega_estimada_desarrollos" class="property-features__input" placeholder="Ej. 4T 2025">
+                                    </div>
+                                </div>
+                                <div class="property-features__toggle-group" role="group" aria-labelledby="feature-desarrollo-amenidades">
+                                    <span id="feature-desarrollo-amenidades" class="property-features__toggle-group-title">Amenidades destacadas</span>
+                                    <div class="property-features__toggle-list">
+                                        <label class="property-features__toggle" for="feature-desarrollo-alberca">
+                                            <input type="checkbox" id="feature-desarrollo-alberca" name="alberca_desarrollos">
+                                            <span class="property-features__toggle-icon" aria-hidden="true">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M4 15c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
+                                                    <path d="M4 11c1.5 0 1.5 1 3 1s1.5-1 3-1 1.5 1 3 1 1.5-1 3-1 1.5 1 3 1" fill="none" stroke="#0284c7" stroke-width="1.6" stroke-linecap="round"/>
+                                                </svg>
+                                            </span>
+                                            <span>Alberca</span>
+                                        </label>
+                                        <label class="property-features__toggle" for="feature-desarrollo-areas-verdes">
+                                            <input type="checkbox" id="feature-desarrollo-areas-verdes" name="areas_verdes_desarrollos">
+                                            <span class="property-features__toggle-icon" aria-hidden="true">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M12 4c3 3 5 5.5 5 8.5a5 5 0 0 1-10 0C7 9.5 9 7 12 4Z" fill="#dcfce7" stroke="#16a34a" stroke-width="1.4"/>
+                                                </svg>
+                                            </span>
+                                            <span>Áreas verdes</span>
+                                        </label>
+                                        <label class="property-features__toggle" for="feature-desarrollo-gimnasio">
+                                            <input type="checkbox" id="feature-desarrollo-gimnasio" name="gimnasio_desarrollos">
+                                            <span class="property-features__toggle-icon" aria-hidden="true">
+                                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M5 8h2v8H5zM17 8h2v8h-2z" fill="#60a5fa"/>
+                                                    <rect x="8" y="6" width="8" height="12" rx="2" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.4"/>
+                                                </svg>
+                                            </span>
+                                            <span>Gimnasio</span>
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="property-features__toggles">
+                                    <label class="property-features__toggle" for="feature-desarrollo-pet-friendly">
+                                        <input type="checkbox" id="feature-desarrollo-pet-friendly" name="pet_friendly_desarrollos">
+                                        <span class="property-features__toggle-icon" aria-hidden="true">
+                                            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                <path d="M8 11a4 4 0 0 1 8 0v1a4 4 0 0 1-8 0Z" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.4"/>
+                                                <circle cx="7" cy="8" r="1.5" fill="#f59e0b"/>
+                                                <circle cx="17" cy="8" r="1.5" fill="#f59e0b"/>
+                                            </svg>
+                                        </span>
+                                        <span>Pet friendly</span>
+                                    </label>
+                                </div>
+                                <footer class="feature-card__footer">
+                                    <p class="feature-card__footnote">Tip: Comparte avances por etapa, esquemas de inversión y garantías para generar confianza.</p>
+                                </footer>
+                            </div>
+                                    </article>
+                    </div>
+                </div>
+                <aside class="property-features__aside">
+                    <section class="feature-summary-card" aria-labelledby="feature-summary-heading">
+                        <header class="feature-summary-card__header">
+                            <h4 id="feature-summary-heading">Resumen de tu ficha</h4>
+                            <p class="feature-summary-card__caption">Monitorea el avance y destaca los datos esenciales antes de publicar.</p>
+                        </header>
+                        <div class="feature-summary-card__progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" data-feature-progress-bar>
+                            <span class="feature-summary-card__progress-value" data-feature-progress-value>0%</span>
+                            <div class="feature-summary-card__progress-track">
+                                <div class="feature-summary-card__progress-fill" data-feature-progress-fill></div>
                             </div>
                         </div>
-                    </div>
+                        <dl class="feature-summary-card__stats" data-feature-summary-list>
+                            <div class="feature-summary-card__stat">
+                                <dt>Campos completos</dt>
+                                <dd data-feature-summary-completed>0</dd>
+                            </div>
+                            <div class="feature-summary-card__stat">
+                                <dt>Campos restantes</dt>
+                                <dd data-feature-summary-pending>0</dd>
+                            </div>
+                            <div class="feature-summary-card__stat">
+                                <dt>Última actualización</dt>
+                                <dd data-feature-summary-updated>Hace unos segundos</dd>
+                            </div>
+                        </dl>
+                        <footer class="feature-summary-card__footer">
+                            <button type="button" class="feature-summary-card__action" data-preview-features>Vista previa profesional</button>
+                        </footer>
+                    </section>
+
+                    <section class="feature-tips-card" aria-labelledby="feature-tips-heading">
+                        <h4 id="feature-tips-heading">Recomendaciones</h4>
+                        <ul class="feature-tips-card__list">
+                            <li>Incluye amenidades únicas y políticas de mantenimiento para generar confianza.</li>
+                            <li>Utiliza medidas exactas y especifica si son áreas privativas o comunes.</li>
+                            <li>Describe entregables especiales como mobiliario, equipamiento o membresías.</li>
+                        </ul>
+                        <div class="feature-tips-card__cta">
+                            <span class="feature-tips-card__cta-label">¿Necesitas inspiración?</span>
+                            <a href="#" class="feature-tips-card__link" data-feature-inspiration>Ver ejemplos de fichas destacadas</a>
+                        </div>
+                    </section>
+                </aside>
+            </div>
+        </div>
 
                     <div class="publish-details__actions publish-details__actions--between">
                         <button type="button" class="modal__action" data-details-prev>Volver a información</button>


### PR DESCRIPTION
## Summary
- redesign the property features step with a search toolbar, quick chips, and updated feature cards
- add a professional summary panel and recommendations sidebar with supporting styles
- enhance modal interactions with expand/collapse controls, search highlighting, and progress tracking logic

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e027b2951483208c9936c5bf354d00