### PR TITLE
Improve publish details modal features layout

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6597,7 +6597,8 @@ body.profile-page {
 }
 
 .modal-publish-details {
-    max-width: 720px;
+    width: min(100vw - 32px, 920px);
+    max-width: none;
     max-height: calc(100vh - 96px);
     padding: 48px 56px;
     text-align: left;
@@ -7122,6 +7123,92 @@ body.profile-page {
     display: flex;
 }
 
+.publish-details__step.property-features {
+    padding: 32px 32px 36px;
+    border-radius: 28px;
+    border: 1.5px solid rgba(148, 163, 184, 0.35);
+    background: linear-gradient(160deg, rgba(248, 250, 252, 0.98), rgba(219, 234, 254, 0.65));
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+    gap: 28px;
+}
+
+.publish-details__step.property-features .property-features__header {
+    padding: 24px 28px;
+    border-radius: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.08);
+    gap: 20px;
+}
+
+.publish-details__step.property-features .property-features__header-main {
+    align-items: stretch;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.publish-details__step.property-features .property-features__actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.publish-details__step.property-features .property-features__type {
+    flex: 1;
+    flex-wrap: wrap;
+    background: rgba(248, 250, 252, 0.95);
+    border: 1px solid rgba(203, 213, 225, 0.65);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6), 0 12px 28px rgba(15, 23, 42, 0.06);
+}
+
+.publish-details__step.property-features .property-features__badge-group {
+    justify-content: flex-end;
+}
+
+.publish-details__step.property-features .property-features__content {
+    padding-top: 4px;
+    gap: 32px;
+}
+
+.publish-details__step.property-features .property-features__layout {
+    gap: 36px;
+}
+
+.publish-details__step.property-features .property-features__primary {
+    gap: 28px;
+}
+
+.publish-details__step.property-features .property-features__groups {
+    display: grid;
+    gap: 28px;
+}
+
+.publish-details__step.property-features .feature-card {
+    background: rgba(255, 255, 255, 0.98);
+}
+
+@media (max-width: 900px) {
+    .publish-details__step.property-features {
+        padding: 28px 24px 32px;
+        border-radius: 24px;
+    }
+
+    .publish-details__step.property-features .property-features__header {
+        padding: 20px 22px;
+    }
+}
+
+@media (max-width: 768px) {
+    .publish-details__step.property-features {
+        padding: 24px 20px 28px;
+        border-radius: 22px;
+        gap: 24px;
+    }
+
+    .publish-details__step.property-features .property-features__header-main {
+        gap: 16px;
+    }
+}
+
 .property-features__header {
     display: flex;
     flex-direction: column;
@@ -7288,6 +7375,10 @@ body.profile-page {
 @media (max-width: 1100px) {
     .property-features__layout {
         grid-template-columns: 1fr;
+    }
+
+    .property-features__aside {
+        position: static;
     }
 }
 
@@ -7656,6 +7747,8 @@ body.profile-page {
     display: flex;
     flex-direction: column;
     gap: 24px;
+    position: sticky;
+    top: 0;
 }
 
 .feature-summary-card,
@@ -7866,8 +7959,8 @@ body.profile-page {
 
 @media (max-width: 900px) {
     .modal-publish-details {
+        width: min(100vw - 24px, 720px);
         padding: 40px 28px;
-        max-width: 90vw;
     }
 
     .publish-details__grid {

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -227,7 +227,7 @@
                     </div>
                 </section>
 
-                <section class="publish-details__step" data-details-step="features">
+                <section class="publish-details__step property-features" data-details-step="features">
                     <header class="property-features__header">
                         <div class="property-features__header-main">
                             <div>


### PR DESCRIPTION
## Summary
- widen the publish details modal and restyle the features step to present information in a clearer card layout
- add responsive tweaks that preserve spacing on smaller screens and keep the summary sidebar sticky on wide viewports

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e02cbe53588320a72a2180a8d24902