### PR TITLE
Add pricing modal after property details submission

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6630,6 +6630,282 @@ body.profile-page {
     background: linear-gradient(180deg, #60a5fa, #2563eb);
 }
 
+.modal-pricing {
+    max-width: 640px;
+    max-height: calc(100vh - 96px);
+    padding: 44px 48px;
+    background: linear-gradient(160deg, #ffffff 55%, rgba(37, 99, 235, 0.08) 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(37, 99, 235, 0.4) transparent;
+}
+
+.modal-pricing::-webkit-scrollbar {
+    width: 10px;
+}
+
+.modal-pricing::-webkit-scrollbar-track {
+    background: rgba(191, 219, 254, 0.35);
+    border-radius: 999px;
+}
+
+.modal-pricing::-webkit-scrollbar-thumb {
+    background: linear-gradient(180deg, rgba(59, 130, 246, 0.8), rgba(37, 99, 235, 0.9));
+    border-radius: 999px;
+}
+
+.modal-pricing__header {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.modal-pricing__badge {
+    align-self: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: rgba(37, 99, 235, 0.08);
+    color: #2563eb;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+}
+
+.modal-pricing__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.modal-pricing__subtitle {
+    color: #64748b;
+    max-width: 420px;
+    margin: 0 auto;
+    font-size: 0.95rem;
+}
+
+.modal-pricing__summary {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 24px;
+    padding: 24px 28px;
+    border-radius: 24px;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(59, 130, 246, 0.16));
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.08);
+    position: relative;
+}
+
+.modal-pricing__summary::after {
+    content: '';
+    position: absolute;
+    inset: 12px;
+    border-radius: 20px;
+    border: 1px dashed rgba(59, 130, 246, 0.2);
+    pointer-events: none;
+}
+
+.modal-pricing__summary-icon svg {
+    width: 64px;
+    height: 64px;
+}
+
+.modal-pricing__summary-details {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.modal-pricing__summary-label {
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #2563eb;
+    font-weight: 600;
+}
+
+.modal-pricing__summary-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.modal-pricing__summary-purpose {
+    color: #334155;
+    line-height: 1.5;
+    font-size: 0.95rem;
+}
+
+.modal-pricing__insight {
+    border-left: 1px solid rgba(37, 99, 235, 0.2);
+    padding-left: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.modal-pricing__insight-title {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #1d4ed8;
+    font-weight: 600;
+}
+
+.modal-pricing__insight-text,
+.modal-pricing__insight-range {
+    color: #1f2937;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.modal-pricing__insight-range {
+    color: #1d4ed8;
+    font-weight: 600;
+}
+
+.modal-pricing__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px;
+}
+
+.modal-pricing__field {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.modal-pricing__field label {
+    font-weight: 600;
+    color: #0f172a;
+    font-size: 0.95rem;
+}
+
+.modal-pricing__field--full {
+    grid-column: 1 / -1;
+}
+
+.modal-pricing__input-group {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: #f8fafc;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 16px;
+    padding: 12px 16px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.modal-pricing__input-group:focus-within {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.modal-pricing__currency {
+    font-weight: 600;
+    color: #1d4ed8;
+    min-width: 48px;
+}
+
+.modal-pricing__input-group input,
+.modal-pricing__input-group select {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    font-size: 1rem;
+    color: #0f172a;
+}
+
+.modal-pricing__select {
+    width: 100%;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    padding: 12px 16px;
+    background: #f8fafc;
+    font-size: 1rem;
+    color: #0f172a;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.modal-pricing__select:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+    outline: none;
+}
+
+.modal-pricing__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.modal-pricing__chip {
+    position: relative;
+    display: inline-flex;
+    cursor: pointer;
+}
+
+.modal-pricing__chip span {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0.55rem 1rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.16);
+    color: #334155;
+    font-weight: 500;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.modal-pricing__chip input {
+    position: absolute;
+    opacity: 0;
+}
+
+.modal-pricing__chip input:checked + span {
+    color: #1d4ed8;
+    font-weight: 600;
+    background: rgba(59, 130, 246, 0.15);
+    box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.25);
+}
+
+.modal-pricing__field textarea {
+    width: 100%;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    padding: 14px 16px;
+    font-size: 1rem;
+    line-height: 1.5;
+    resize: vertical;
+    min-height: 120px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.modal-pricing__field textarea:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.modal-pricing__hint {
+    font-size: 0.85rem;
+    color: #64748b;
+    line-height: 1.5;
+}
+
+.modal-pricing__actions {
+    margin-top: 8px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+}
+
 .modal-publish-details__header {
     text-align: center;
     margin-bottom: 2rem;
@@ -7444,6 +7720,27 @@ body.profile-page {
         max-width: 90vw;
     }
 
+    .modal-pricing {
+        padding: 36px 28px;
+        max-width: 90vw;
+    }
+
+    .modal-pricing__summary {
+        grid-template-columns: 1fr;
+        text-align: left;
+    }
+
+    .modal-pricing__insight {
+        border-left: none;
+        border-top: 1px solid rgba(37, 99, 235, 0.2);
+        padding-left: 0;
+        padding-top: 16px;
+    }
+
+    .modal-pricing__grid {
+        grid-template-columns: 1fr;
+    }
+
     .publish-details__grid {
         grid-template-columns: 1fr;
     }
@@ -7469,6 +7766,23 @@ body.profile-page {
 
     .modal-publish {
         padding: 32px 24px;
+    }
+
+    .modal-pricing {
+        padding: 28px 22px;
+        gap: 24px;
+    }
+
+    .modal-pricing__summary {
+        padding: 20px;
+    }
+
+    .modal-pricing__header {
+        gap: 8px;
+    }
+
+    .modal-pricing__title {
+        font-size: 1.5rem;
     }
 
     .modal-publish__options--grid {

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -785,3 +785,112 @@
 
     </div>
 </div>
+
+<div class="modal" data-modal="publish-pricing" aria-hidden="true" role="dialog">
+    <div class="modal__overlay" data-modal-close></div>
+    <div class="modal__dialog modal-pricing" role="document">
+        <button class="modal__close" type="button" aria-label="Cerrar" data-modal-close>&times;</button>
+        <header class="modal-pricing__header">
+            <span class="modal-pricing__badge">Estrategia comercial</span>
+            <h2 class="modal-pricing__title">Define el precio de lanzamiento</h2>
+            <p class="modal-pricing__subtitle">Establece un valor competitivo alineado al mercado y al objetivo de la propiedad.</p>
+        </header>
+
+        <section class="modal-pricing__summary" aria-live="polite">
+            <div class="modal-pricing__summary-icon" aria-hidden="true">
+                <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                    <rect x="6" y="10" width="52" height="44" rx="12" fill="rgba(59,130,246,0.08)" />
+                    <path d="M20 36h24" stroke="#2563eb" stroke-width="3" stroke-linecap="round" />
+                    <path d="M26 26h12" stroke="#2563eb" stroke-width="3" stroke-linecap="round" />
+                    <circle cx="32" cy="22" r="4" fill="#2563eb" />
+                </svg>
+            </div>
+            <div class="modal-pricing__summary-details">
+                <span class="modal-pricing__summary-label">Propiedad</span>
+                <p class="modal-pricing__summary-title" data-pricing-type>Tipo de propiedad no definido</p>
+                <p class="modal-pricing__summary-purpose" data-pricing-purpose>Selecciona un propósito comercial para recibir recomendaciones personalizadas.</p>
+            </div>
+            <div class="modal-pricing__insight">
+                <span class="modal-pricing__insight-title">Recomendación</span>
+                <p class="modal-pricing__insight-text" data-pricing-suggestion>Añade metraje, amenidades y ubicación para estimar un rango competitivo.</p>
+                <p class="modal-pricing__insight-range" data-pricing-range>Comparte detalles clave para generar un rango estimado.</p>
+            </div>
+        </section>
+
+        <form class="publish-pricing" data-pricing-form>
+            <div class="modal-pricing__grid">
+                <div class="modal-pricing__field">
+                    <label for="pricing-currency">Moneda de referencia</label>
+                    <div class="modal-pricing__input-group">
+                        <select id="pricing-currency" name="currency" class="modal-pricing__select" data-pricing-currency>
+                            <option value="mxn" selected>MXN - Peso mexicano</option>
+                            <option value="usd">USD - Dólar estadounidense</option>
+                        </select>
+                    </div>
+                    <p class="modal-pricing__hint">Selecciona la divisa que usarás para publicar el precio.</p>
+                </div>
+
+                <div class="modal-pricing__field">
+                    <label for="pricing-amount">Precio de lista</label>
+                    <div class="modal-pricing__input-group">
+                        <span class="modal-pricing__currency" data-pricing-currency-symbol>$</span>
+                        <input type="number" id="pricing-amount" name="price" min="0" step="1000" placeholder="Ej. 3,250,000" data-pricing-amount required>
+                    </div>
+                    <p class="modal-pricing__hint">Define un monto competitivo acorde a la zona, plusvalía y estado del inmueble.</p>
+                </div>
+
+                <div class="modal-pricing__field">
+                    <label for="pricing-negotiation">Estrategia de negociación</label>
+                    <div class="modal-pricing__chips" role="group" aria-label="Estrategia de negociación">
+                        <label class="modal-pricing__chip">
+                            <input type="radio" name="negotiation" value="firme" checked>
+                            <span>Precio firme</span>
+                        </label>
+                        <label class="modal-pricing__chip">
+                            <input type="radio" name="negotiation" value="negociable">
+                            <span>Negociable</span>
+                        </label>
+                        <label class="modal-pricing__chip">
+                            <input type="radio" name="negotiation" value="con-incentivos">
+                            <span>Incluye incentivos</span>
+                        </label>
+                    </div>
+                    <p class="modal-pricing__hint">Determina si considerarás contraofertas, incentivos o beneficios adicionales.</p>
+                </div>
+
+                <div class="modal-pricing__field">
+                    <label for="pricing-maintenance">Cuota de mantenimiento</label>
+                    <div class="modal-pricing__input-group">
+                        <span class="modal-pricing__currency" aria-hidden="true">$</span>
+                        <input type="number" id="pricing-maintenance" name="maintenance" min="0" step="100" placeholder="Ej. 1,800">
+                    </div>
+                    <p class="modal-pricing__hint">Incluye gastos mensuales o cuotas de administración si aplican.</p>
+                </div>
+
+                <div class="modal-pricing__field">
+                    <label for="pricing-availability">Disponibilidad estimada</label>
+                    <select id="pricing-availability" name="availability" class="modal-pricing__select">
+                        <option value="inmediata" selected>Entrega inmediata</option>
+                        <option value="30">Disponible en 30 días</option>
+                        <option value="60">Disponible en 60 días</option>
+                        <option value="90">Disponible en 90 días</option>
+                        <option value="personalizada">Fecha personalizada</option>
+                    </select>
+                    <p class="modal-pricing__hint">Comunica desde cuándo se puede ocupar la propiedad.</p>
+                </div>
+
+                <div class="modal-pricing__field modal-pricing__field--full">
+                    <label for="pricing-notes">Notas para clientes potenciales</label>
+                    <textarea id="pricing-notes" name="notes" rows="3" placeholder="Describe condiciones especiales, facilidades de pago o requisitos para visitar la propiedad."></textarea>
+                    <p class="modal-pricing__hint">Comparte información adicional que ayude a filtrar prospectos calificados.</p>
+                </div>
+            </div>
+
+            <div class="modal-pricing__actions">
+                <button type="button" class="modal__action" data-modal-close>Asignar precio más tarde</button>
+                <button type="submit" class="dashboard__action-btn dashboard__action-btn--primary">Guardar precio</button>
+            </div>
+        </form>
+    </div>
+</div>
+


### PR DESCRIPTION
## Summary
- add a dedicated pricing modal to complete the publish flow after guardar ficha profesional
- style the new modal with polished layout, chips, and responsive tweaks
- update profile.js to open the pricing modal after features are saved and show contextual info such as purpose, type, and currency hints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e186b3cb5c83209a4b68ca11d5c583