### PR TITLE
Format pricing input with thousands separators

### DIFF
--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -812,7 +812,7 @@
                 <label for="publish-price" data-pricing-label>Precio de venta</label>
                 <div class="publish-pricing__input-group">
                     <span class="publish-pricing__currency" data-pricing-currency-symbol>$</span>
-                    <input type="number" id="publish-price" name="price" inputmode="decimal" min="0" step="0.01" placeholder="Ej. 4,500,000" data-pricing-input required>
+                    <input type="text" id="publish-price" name="price" inputmode="decimal" placeholder="Ej. 4,500,000" data-pricing-input required>
                     <div class="publish-pricing__currency-select" data-currency-select>
                         <button class="publish-pricing__currency-trigger" type="button" data-currency-trigger aria-haspopup="listbox" aria-expanded="false">
                             <span class="publish-pricing__currency-trigger-label" data-currency-label>MXN · Peso mexicano</span>


### PR DESCRIPTION
## Summary
- convert the publish price input to text so formatted values can be shown while typing
- add parsing and formatting helpers to insert thousands separators and keep a sanitized numeric dataset value
- adjust validation to use the sanitized numeric price when submitting the pricing form

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3483a76608320bb3d6c7b8224dc2e