### PR TITLE
Add live formatted display for publish price input

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6707,6 +6707,7 @@ body.profile-page {
     padding: 14px 18px;
     background-color: #ffffff;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    position: relative;
 }
 
 .publish-pricing__input-group:focus-within {
@@ -6725,6 +6726,56 @@ body.profile-page {
     color: #2563eb;
 }
 
+.publish-pricing__input-wrapper {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+}
+
+.publish-pricing__input-display {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #0f172a;
+    pointer-events: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: opacity 0.2s ease;
+}
+
+.publish-pricing__input-wrapper[data-has-value="false"] .publish-pricing__input-display {
+    opacity: 0;
+}
+
+.publish-pricing__input-wrapper[data-has-value="true"] .publish-pricing__input-display {
+    opacity: 1;
+}
+
+.publish-pricing__input-wrapper input[type="number"] {
+    border: 0;
+    outline: none;
+    width: 100%;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #0f172a;
+    background: transparent;
+    position: relative;
+    z-index: 1;
+    caret-color: #0f172a;
+}
+
+.publish-pricing__input-wrapper[data-has-value="true"] input[type="number"] {
+    color: transparent;
+}
+
+.publish-pricing__input-wrapper[data-has-value="true"] input[type="number"]::placeholder {
+    color: transparent;
+}
+
 .publish-pricing__input-group input[type="number"] {
     border: 0;
     outline: none;
@@ -6733,6 +6784,11 @@ body.profile-page {
     font-weight: 600;
     color: #0f172a;
     background: transparent;
+}
+
+.publish-pricing__input-group input[type="number"]::placeholder {
+    color: #94a3b8;
+    opacity: 1;
 }
 
 .publish-pricing__input-group input[type="number"]::-webkit-outer-spin-button,

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -504,6 +504,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const form = modalElement.querySelector('[data-pricing-form]');
             const backButton = modalElement.querySelector('[data-pricing-back]');
             const priceInput = modalElement.querySelector('[data-pricing-input]');
+            const priceInputWrapper = modalElement.querySelector('[data-pricing-input-wrapper]');
+            const priceDisplay = modalElement.querySelector('[data-pricing-display]');
             const inputGroup = modalElement.querySelector('.publish-pricing__input-group');
             const helper = modalElement.querySelector('[data-pricing-helper]');
             const errorMessage = modalElement.querySelector('[data-pricing-error]');
@@ -632,6 +634,57 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             };
 
+            const formatPriceForDisplay = (value) => {
+                if (typeof value !== 'string') {
+                    return '';
+                }
+
+                const sanitizedValue = value.replace(/[^0-9.]/g, '');
+                if (!sanitizedValue) {
+                    return '';
+                }
+
+                const parts = sanitizedValue.split('.');
+                const integerPart = parts[0] || '';
+                if (!integerPart) {
+                    return '';
+                }
+
+                const numericInteger = Number(integerPart);
+                if (!Number.isFinite(numericInteger)) {
+                    return '';
+                }
+
+                const formattedInteger = numericInteger.toLocaleString('es-MX');
+                if (parts.length === 1) {
+                    return formattedInteger;
+                }
+
+                const decimalPart = parts[1] || '';
+                if (decimalPart.length === 0) {
+                    return `${formattedInteger}.`;
+                }
+
+                return `${formattedInteger}.${decimalPart.slice(0, 2)}`;
+            };
+
+            const updatePriceDisplay = () => {
+                if (!priceInput || !priceInputWrapper || !priceDisplay) {
+                    return;
+                }
+
+                const rawValue = priceInput.value ? priceInput.value.trim() : '';
+                const formattedValue = formatPriceForDisplay(rawValue);
+
+                if (formattedValue) {
+                    priceDisplay.textContent = formattedValue;
+                    priceInputWrapper.dataset.hasValue = 'true';
+                } else {
+                    priceDisplay.textContent = '';
+                    priceInputWrapper.dataset.hasValue = 'false';
+                }
+            };
+
             const updateCurrencyState = (option) => {
                 if (!option) {
                     return;
@@ -697,6 +750,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     priceInput.placeholder = isRent ? 'Ej. 25,000' : 'Ej. 4,500,000';
                     priceInput.value = '';
                 }
+
+                updatePriceDisplay();
 
                 if (currencySelect && currencySelect.options.length) {
                     const options = Array.from(currencySelect.options);
@@ -794,6 +849,11 @@ document.addEventListener('DOMContentLoaded', () => {
             if (priceInput) {
                 priceInput.addEventListener('input', () => {
                     resetErrorState();
+                    updatePriceDisplay();
+                });
+
+                priceInput.addEventListener('change', () => {
+                    updatePriceDisplay();
                 });
             }
 

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -812,7 +812,10 @@
                 <label for="publish-price" data-pricing-label>Precio de venta</label>
                 <div class="publish-pricing__input-group">
                     <span class="publish-pricing__currency" data-pricing-currency-symbol>$</span>
-                    <input type="number" id="publish-price" name="price" inputmode="decimal" min="0" step="0.01" placeholder="Ej. 4,500,000" data-pricing-input required>
+                    <div class="publish-pricing__input-wrapper" data-pricing-input-wrapper data-has-value="false">
+                        <span class="publish-pricing__input-display" data-pricing-display aria-hidden="true"></span>
+                        <input type="number" id="publish-price" name="price" inputmode="decimal" min="0" step="0.01" placeholder="Ej. 4,500,000" data-pricing-input required>
+                    </div>
                     <div class="publish-pricing__currency-select" data-currency-select>
                         <button class="publish-pricing__currency-trigger" type="button" data-currency-trigger aria-haspopup="listbox" aria-expanded="false">
                             <span class="publish-pricing__currency-trigger-label" data-currency-label>MXN · Peso mexicano</span>


### PR DESCRIPTION
## Summary
- wrap the pricing input with a formatted display element so the numeric field keeps thousands separators while typing
- add styles for the pricing input overlay without altering the existing layout
- update the profile scripts to format and sync the displayed value with the underlying number input

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e46a96651c8320a898d8e2953c3c97