### PR TITLE
Formatear visualmente el precio en el modal de publicación

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6709,6 +6709,33 @@ body.profile-page {
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.publish-pricing__input-wrapper {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+}
+
+.publish-pricing__formatted-value {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    pointer-events: none;
+    color: #0f172a;
+    font-size: 1.1rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.publish-pricing__formatted-value.is-placeholder {
+    color: #94a3b8;
+    font-weight: 500;
+}
+
 .publish-pricing__input-group:focus-within {
     border-color: #2563eb;
     box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
@@ -6733,6 +6760,15 @@ body.profile-page {
     font-weight: 600;
     color: #0f172a;
     background: transparent;
+}
+
+.publish-pricing__input-wrapper input[type="number"] {
+    color: transparent;
+    caret-color: #0f172a;
+}
+
+.publish-pricing__input-wrapper input[type="number"]::placeholder {
+    color: transparent;
 }
 
 .publish-pricing__input-group input[type="number"]::-webkit-outer-spin-button,

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -505,6 +505,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const backButton = modalElement.querySelector('[data-pricing-back]');
             const priceInput = modalElement.querySelector('[data-pricing-input]');
             const inputGroup = modalElement.querySelector('.publish-pricing__input-group');
+            const formattedPriceValue = modalElement.querySelector('[data-pricing-formatted]');
             const helper = modalElement.querySelector('[data-pricing-helper]');
             const errorMessage = modalElement.querySelector('[data-pricing-error]');
             const priceLabel = modalElement.querySelector('[data-pricing-label]');
@@ -530,6 +531,54 @@ document.addEventListener('DOMContentLoaded', () => {
                 purposeLabel: '',
                 type: null,
                 typeLabel: ''
+            };
+
+            const formatPriceDisplay = (rawValue = '') => {
+                if (!rawValue) {
+                    return '';
+                }
+
+                const stringValue = String(rawValue);
+                const parts = stringValue.split('.');
+                const rawIntegerPart = parts[0] || '';
+                const rawFractionalPart = parts[1] || '';
+                const digitsOnly = rawIntegerPart.replace(/\D/g, '');
+
+                if (!digitsOnly && !rawFractionalPart) {
+                    return '';
+                }
+
+                const normalizedInteger = (digitsOnly.replace(/^0+(?=\d)/, '') || '0');
+                const groupedInteger = normalizedInteger.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+                if (stringValue.endsWith('.') && !rawFractionalPart) {
+                    return `${groupedInteger}.`;
+                }
+
+                if (rawFractionalPart) {
+                    return `${groupedInteger}.${rawFractionalPart}`;
+                }
+
+                return groupedInteger;
+            };
+
+            const updateFormattedPriceDisplay = () => {
+                if (!priceInput || !formattedPriceValue) {
+                    return;
+                }
+
+                const { value } = priceInput;
+
+                if (!value) {
+                    formattedPriceValue.textContent = priceInput.placeholder || '';
+                    formattedPriceValue.classList.add('is-placeholder');
+                    return;
+                }
+
+                const formattedValue = formatPriceDisplay(value);
+
+                formattedPriceValue.textContent = formattedValue;
+                formattedPriceValue.classList.remove('is-placeholder');
             };
 
             const closeCurrencyDropdown = () => {
@@ -696,6 +745,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (priceInput) {
                     priceInput.placeholder = isRent ? 'Ej. 25,000' : 'Ej. 4,500,000';
                     priceInput.value = '';
+                    updateFormattedPriceDisplay();
                 }
 
                 if (currencySelect && currencySelect.options.length) {
@@ -726,6 +776,15 @@ document.addEventListener('DOMContentLoaded', () => {
                     const selectedOption = currencySelect.options[currencySelect.selectedIndex];
                     updateCurrencyState(selectedOption);
                 });
+            }
+
+            if (priceInput && formattedPriceValue) {
+                ['input', 'change'].forEach(eventName => {
+                    priceInput.addEventListener(eventName, updateFormattedPriceDisplay);
+                });
+                priceInput.addEventListener('focus', updateFormattedPriceDisplay);
+                priceInput.addEventListener('blur', updateFormattedPriceDisplay);
+                updateFormattedPriceDisplay();
             }
 
             const handleCurrencyOptionSelection = (item) => {

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -812,7 +812,10 @@
                 <label for="publish-price" data-pricing-label>Precio de venta</label>
                 <div class="publish-pricing__input-group">
                     <span class="publish-pricing__currency" data-pricing-currency-symbol>$</span>
-                    <input type="number" id="publish-price" name="price" inputmode="decimal" min="0" step="0.01" placeholder="Ej. 4,500,000" data-pricing-input required>
+                    <div class="publish-pricing__input-wrapper" data-pricing-input-wrapper>
+                        <input type="number" id="publish-price" name="price" inputmode="decimal" min="0" step="0.01" placeholder="Ej. 4,500,000" data-pricing-input required>
+                        <span class="publish-pricing__formatted-value" data-pricing-formatted aria-hidden="true"></span>
+                    </div>
                     <div class="publish-pricing__currency-select" data-currency-select>
                         <button class="publish-pricing__currency-trigger" type="button" data-currency-trigger aria-haspopup="listbox" aria-expanded="false">
                             <span class="publish-pricing__currency-trigger-label" data-currency-label>MXN · Peso mexicano</span>


### PR DESCRIPTION
## Summary
- envolver el campo de precio con un contenedor que muestra el monto formateado con separadores de miles
- aplicar estilos para presentar el texto formateado sin alterar el diseño existente del grupo de entrada
- actualizar la lógica del modal para mantener el valor formateado sincronizado con el número capturado

## Testing
- no se realizaron pruebas automatizadas (frontend estático)


------
https://chatgpt.com/codex/tasks/task_e_68e47a75c6008320a274916010d7b7d1