### PR TITLE
Improve pricing input caret and selection styling

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -7037,6 +7037,23 @@ body.profile-page {
     min-height: 140px;
 }
 
+.publish-details__field input[data-pricing-input] {
+    caret-color: #2563eb;
+    font-variant-numeric: tabular-nums;
+    -moz-appearance: textfield;
+}
+
+.publish-details__field input[data-pricing-input]::selection {
+    background-color: rgba(37, 99, 235, 0.18);
+    color: #0f172a;
+}
+
+.publish-details__field input[data-pricing-input]::-webkit-inner-spin-button,
+.publish-details__field input[data-pricing-input]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
 .publish-details__hint {
     font-size: 13px;
     color: #64748b;


### PR DESCRIPTION
## Summary
- improve the appearance of the pricing field caret and selection colors inside the publishing modal
- remove default browser spin buttons to keep the number input visual consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e47d8a600c8320ba44564bf514ef54