### PR TITLE
Format pricing input with thousand separators

### DIFF
--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -812,7 +812,7 @@
                 <label for="publish-price" data-pricing-label>Precio de venta</label>
                 <div class="publish-pricing__input-group">
                     <span class="publish-pricing__currency" data-pricing-currency-symbol>$</span>
-                    <input type="number" id="publish-price" name="price" inputmode="decimal" min="0" step="0.01" placeholder="Ej. 4,500,000" data-pricing-input required>
+                    <input type="text" id="publish-price" name="price" inputmode="decimal" pattern="[0-9.,]*" placeholder="Ej. 4,500,000" data-pricing-input required>
                     <div class="publish-pricing__currency-select" data-currency-select>
                         <button class="publish-pricing__currency-trigger" type="button" data-currency-trigger aria-haspopup="listbox" aria-expanded="false">
                             <span class="publish-pricing__currency-trigger-label" data-currency-label>MXN · Peso mexicano</span>


### PR DESCRIPTION
## Summary
- format the publish price field in the pricing modal as the user types, adding thousand separators while keeping a clean numeric value
- normalize price submission data so the stored value remains numeric despite the formatted display
- switch the modal price input to text with a numeric keyboard hint to support the live formatting

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4880740748320b4abdebc4cd0d341