### PR TITLE
Format price input while typing

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6725,7 +6725,7 @@ body.profile-page {
     color: #2563eb;
 }
 
-.publish-pricing__input-group input[type="number"] {
+.publish-pricing__input-group input[data-pricing-input] {
     border: 0;
     outline: none;
     width: 100%;
@@ -6733,16 +6733,6 @@ body.profile-page {
     font-weight: 600;
     color: #0f172a;
     background: transparent;
-}
-
-.publish-pricing__input-group input[type="number"]::-webkit-outer-spin-button,
-.publish-pricing__input-group input[type="number"]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-}
-
-.publish-pricing__input-group input[type="number"] {
-    -moz-appearance: textfield;
 }
 
 .publish-pricing__hint {

--- a/frontend/assets/templates/profile/propiedades.html
+++ b/frontend/assets/templates/profile/propiedades.html
@@ -812,7 +812,7 @@
                 <label for="publish-price" data-pricing-label>Precio de venta</label>
                 <div class="publish-pricing__input-group">
                     <span class="publish-pricing__currency" data-pricing-currency-symbol>$</span>
-                    <input type="number" id="publish-price" name="price" inputmode="decimal" min="0" step="0.01" placeholder="Ej. 4,500,000" data-pricing-input required>
+                    <input type="text" id="publish-price" name="price" inputmode="decimal" placeholder="Ej. 4,500,000" data-pricing-input required>
                     <div class="publish-pricing__currency-select" data-currency-select>
                         <button class="publish-pricing__currency-trigger" type="button" data-currency-trigger aria-haspopup="listbox" aria-expanded="false">
                             <span class="publish-pricing__currency-trigger-label" data-currency-label>MXN · Peso mexicano</span>


### PR DESCRIPTION
## Summary
- allow the publish price input to accept formatted values while keeping existing styling
- format and sanitize price values in the pricing modal while the user types and on submit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e54425a4a48320ad2b589e1721330f