### PR TITLE
Fix pricing input formatting for grouped values

### DIFF
--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -547,7 +547,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 const lastComma = cleanedValue.lastIndexOf(',');
                 const lastDot = cleanedValue.lastIndexOf('.');
-                const decimalIndex = Math.max(lastComma, lastDot);
+                let decimalIndex = Math.max(lastComma, lastDot);
+
+                if (decimalIndex > -1) {
+                    const decimalCandidate = cleanedValue.slice(decimalIndex + 1);
+                    const decimalDigits = decimalCandidate.replace(/[^\d]/g, '');
+                    const hasGroupingSeparators = /[.,]/.test(decimalCandidate);
+                    const isValidDecimal = decimalDigits.length <= 2 && !hasGroupingSeparators;
+
+                    if (!isValidDecimal) {
+                        decimalIndex = -1;
+                    }
+                }
 
                 let integerSection = cleanedValue;
                 let decimalSection = '';


### PR DESCRIPTION
## Summary
- update the pricing modal formatter to ignore grouping separators when determining the decimal part
- ensure entering large amounts such as 4.500.000 keeps the intended integer value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e547ace5ec83209e489a628802adbd