### PR TITLE
Adjust pricing modal spacing

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -6596,10 +6596,10 @@ body.profile-page {
     box-shadow: none;
 }
 
-.modal-publish-details { 
+.modal-publish-details {
     max-width: 720px;
     max-height: calc(100vh - 96px);
-    padding: 48px 56px;
+    padding: 48px 56px 36px;
     text-align: left;
     display: flex;
     flex-direction: column;
@@ -6609,6 +6609,10 @@ body.profile-page {
     scrollbar-width: thin;
     scrollbar-color: #60a5fa rgba(148, 163, 184, 0.18);
     scrollbar-gutter: stable both-edges;
+}
+
+.publish-details__step[data-details-step="pricing"] {
+    gap: 24px;
 }
 
 .modal-pricing {
@@ -7731,7 +7735,7 @@ body.profile-page {
 
 @media (max-width: 900px) {
     .modal-publish-details {
-        padding: 40px 28px;
+        padding: 40px 28px 24px;
         max-width: 90vw;
     }
 


### PR DESCRIPTION
## Summary
- reduce the publish modal padding to remove excess scroll space on the pricing step
- tighten the spacing within the pricing step content for a more compact layout
- keep the responsive padding balanced on smaller screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5579e1b80832086bef971c7d3480f