### PR TITLE
Ajusta espacio dinámico para el selector de moneda

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -7408,6 +7408,16 @@ body.profile-page {
     gap: 32px;
 }
 
+.publish-details__step[data-details-step="pricing"] {
+    --pricing-currency-dropdown-space: 0px;
+    padding-bottom: var(--pricing-currency-dropdown-space);
+    transition: padding-bottom 0.2s ease;
+}
+
+.publish-details__step[data-details-step="pricing"].is-currency-dropdown-open {
+    --pricing-currency-dropdown-space: 200px;
+}
+
 .publish-details__step--active,
 .publish-details__step.is-active {
     display: flex;

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -92,6 +92,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 desarrollo: 'Desarrollo'
             };
 
+            const setCurrencyDropdownSpacing = (isOpen) => {
+                if (!pricingSection) {
+                    return;
+                }
+                pricingSection.classList.toggle('is-currency-dropdown-open', Boolean(isOpen));
+            };
+
             const updateFeatureSummary = () => {
                 const displayName = selectedPropertyTypeLabel || propertyTypeNames[selectedPropertyType] || '';
                 if (featureTypeLabel) {
@@ -182,6 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 isCurrencyDropdownOpen = false;
                 customCurrencySelect.classList.remove('is-open');
+                setCurrencyDropdownSpacing(false);
                 document.removeEventListener('click', handleCurrencyOutsideClick);
                 document.removeEventListener('keydown', handleCurrencyKeyDown);
             };
@@ -195,6 +203,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (currencyTrigger) {
                     currencyTrigger.setAttribute('aria-expanded', 'true');
                 }
+                setCurrencyDropdownSpacing(true);
                 document.addEventListener('click', handleCurrencyOutsideClick);
                 document.addEventListener('keydown', handleCurrencyKeyDown);
             };
@@ -401,6 +410,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     updateCustomCurrencyUI();
                 }
                 closeCurrencyDropdown();
+                setCurrencyDropdownSpacing(false);
             };
 
             const showDetailsStep = (step) => {


### PR DESCRIPTION
## Summary
- añade un espacio inferior dinámico en el paso de precios para que el dropdown de moneda solo reserve altura cuando esté abierto
- actualiza la lógica del modal para alternar el relleno adicional al abrir o cerrar el selector de moneda

## Testing
- no se ejecutaron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68e55c3540d88320b479813772a6ace7