### PR TITLE
Fix mobile publish media resize jitter

### DIFF
--- a/frontend/public/css/partials/profile/propiedades.css
+++ b/frontend/public/css/partials/profile/propiedades.css
@@ -1602,6 +1602,7 @@ button {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 16px;
     align-items: start;
+    overscroll-behavior: contain;
 }
 
 .publish-media__grid > * {
@@ -1628,6 +1629,17 @@ button {
 .publish-media__item:hover {
     box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
     transform: translateY(-2px);
+}
+
+@media (hover: none) and (pointer: coarse) {
+    .publish-media__item:hover {
+        transform: none !important;
+        box-shadow: none !important;
+    }
+
+    .publish-media__item {
+        transition: none !important;
+    }
 }
 
 .publish-media__media {
@@ -1751,6 +1763,11 @@ button {
     justify-content: center;
     cursor: pointer;
     transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.publish-media__controls button,
+.publish-media__control-btn {
+    touch-action: manipulation;
 }
 
 .publish-media__control-btn svg {


### PR DESCRIPTION
### Motivation
- Mobile (especially iOS/Safari) was experiencing scroll “jump”/jitter in the publish media grid because `renderPreviews()` was being invoked on viewport/resize events triggered during touch/scroll and when tapping control buttons. 
- The change aims to eliminate that mobile lag without altering visual design or breaking image actions, drag/ordering, or desktop behavior.

### Description
- Added interaction suppression and width/breakpoint checks to avoid re-rendering on height-only viewport changes by introducing `isInteracting`, `lastViewportWidth`, and `lastBreakpointIsDesktop` and the helper `shouldRerenderOnResize()` that requires a >2px width change or breakpoint change to allow re-rendering.
- Replaced the previous resize handler with a debounced (`200ms`) guarded handler and registered listeners as passive for `resize` and `visualViewport.resize` when available, to avoid blocking scroll.
- Mark taps on the `.publish-media__controls` buttons as interaction (`isInteracting = true`) for `300ms` to prevent re-renders triggered by transient viewport changes while the user is touching controls.
- CSS touch improvements in `propiedades.css`: added `overscroll-behavior: contain` on `.publish-media__grid`, disabled hover transforms/transitions on touch devices via `@media (hover: none) and (pointer: coarse)`, and added `touch-action: manipulation` to control buttons to avoid touch scrolling being blocked.
- Changes are limited to `frontend/src/js/pages/profile/publish.js` and `frontend/public/css/partials/profile/propiedades.css` and do not modify `renderPreviews()` internals or UI behavior on desktop.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967126a6b28832091e105e9f7f6845f)