### PR TITLE
Fix mobile scroll jump in media controls

### DIFF
--- a/frontend/src/js/pages/profile/publish.js
+++ b/frontend/src/js/pages/profile/publish.js
@@ -510,6 +510,39 @@
         const MIN_FILES = 5;
         const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/jpg'];
         const isDesktop = () => window.matchMedia('(min-width: 993px)').matches;
+        const isMobileViewport = () => window.matchMedia('(max-width: 992px)').matches;
+        const runWithScrollAnchor = (anchorId, actionFn) => {
+            const isTouchPointer = window.matchMedia('(pointer: coarse)').matches;
+            if (!isMobileViewport() && !isTouchPointer) {
+                actionFn();
+                return;
+            }
+
+            const beforeEl = grid?.querySelector(`.publish-media__preview[data-image-id="${anchorId}"]`);
+            const beforeTop = beforeEl ? beforeEl.getBoundingClientRect().top : null;
+            const beforeScrollY = window.scrollY;
+
+            actionFn();
+
+            window.requestAnimationFrame(() => {
+                window.requestAnimationFrame(() => {
+                    const afterEl = grid?.querySelector(
+                        `.publish-media__preview[data-image-id="${anchorId}"]`
+                    );
+
+                    if (afterEl && beforeTop !== null) {
+                        const afterTop = afterEl.getBoundingClientRect().top;
+                        const delta = afterTop - beforeTop;
+                        if (Math.abs(delta) > 1) {
+                            window.scrollBy(0, delta);
+                        }
+                        return;
+                    }
+
+                    window.scrollTo(0, beforeScrollY);
+                });
+            });
+        };
 
         let images = [];
         let showAll = false;
@@ -729,13 +762,13 @@
                 }, 300);
                 const action = actionTarget.dataset.action;
                 if (action === 'primary') {
-                    setPrimary(image.id);
+                    runWithScrollAnchor(image.id, () => setPrimary(image.id));
                 }
                 if (action === 'rotate') {
-                    rotateImage(image.id);
+                    runWithScrollAnchor(image.id, () => rotateImage(image.id));
                 }
                 if (action === 'remove') {
-                    removeImage(image.id);
+                    runWithScrollAnchor(image.id, () => removeImage(image.id));
                 }
             });
 


### PR DESCRIPTION
### Motivation
- Clicking media control buttons (`primary` / `rotate` / `remove`) triggers `renderPreviews()` which rebuilds the grid and causes a visible scroll jump on mobile/tablet viewports. 
- The goal is to avoid changing UI or render logic, and only keep the scroll stable on mobile/tablet (<= 992px or touch/coarse pointer). 
- The fix must be JS-only (no HTML/CSS changes) and preserve desktop behavior and drag interactions unchanged. 

### Description
- Added a viewport helper `isMobileViewport` (`window.matchMedia('(max-width: 992px)')`).
- Implemented `runWithScrollAnchor(anchorId, actionFn)` that, on mobile/touch, captures the pre-action card position via the selector `.publish-media__preview[data-image-id="..."]`, runs `actionFn()` and restores scroll after DOM updates using a double `requestAnimationFrame` and compensating `window.scrollBy` (with fallback to `window.scrollTo`).
- Wrapped control click handlers for `primary`, `rotate` and `remove` to call `runWithScrollAnchor(image.id, () => ...)` instead of invoking `setPrimary`/`rotateImage`/`removeImage` directly, leaving those functions and `renderPreviews()` unchanged. 

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696714b207a883209742e9d72d24ed8d)